### PR TITLE
fix: point API calls at the new Render backend

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,6 +1,6 @@
 const userSignUp = document.querySelector("#new-user-signup")
 const signUpMessage = document.querySelector("#sign-up-message")
-const usersURL = "https://rave-mom-app.herokuapp.com/api/v1/users"
+const usersURL = "https://rave-mom-api.onrender.com/api/v1/users"
 
 localStorage.clear()
 
@@ -42,7 +42,7 @@ const gameContainer = document.querySelector("#game-container")
 const welcomeMessage = document.querySelector("#welcome-message")
 const leaderboard = document.querySelector("#leaderboard")
 
-const loginURL = "https://rave-mom-app.herokuapp.com/api/v1/login"
+const loginURL = "https://rave-mom-api.onrender.com/api/v1/login"
 
 userLogin.addEventListener("submit", event => {
     event.preventDefault()
@@ -93,7 +93,7 @@ const leaderboardButton = document.querySelector("#leaderboard-button");
 const leaderboardContainer = document.querySelector("#leaderboard-container");
 const leaderboardClose = document.querySelector("#leaderboard-close");
 
-const scoresURL = "https://rave-mom-app.herokuapp.com/api/v1/scores"
+const scoresURL = "https://rave-mom-api.onrender.com/api/v1/scores"
 
 logOutButton.addEventListener("click", event => {
     localStorage.removeItem("token");

--- a/gamescene.js
+++ b/gamescene.js
@@ -316,7 +316,7 @@ class GameScene extends Phaser.Scene {
 
         gameState.bomb1.on('animationcomplete', function() {
             [playerX, playerY] = getPlayerGridPosition(gameState.player)
-            const scoresURL = "https://rave-mom-app.herokuapp.com/api/v1/scores"
+            const scoresURL = "https://rave-mom-api.onrender.com/api/v1/scores"
 
             if(isArrayInArray(gameState.explosionPositions[randBomb1], [playerX, playerY]) && gameState.gameEnded === false) {
                 gameState.scoreText.x = 60
@@ -361,7 +361,7 @@ class GameScene extends Phaser.Scene {
 
         gameState.bomb2.on('animationcomplete', function() {
             [playerX, playerY] = getPlayerGridPosition(gameState.player)
-            const scoresURL = "https://rave-mom-app.herokuapp.com/api/v1/scores"
+            const scoresURL = "https://rave-mom-api.onrender.com/api/v1/scores"
 
             if(isArrayInArray(gameState.explosionPositions[randBomb2], [playerX, playerY]) && gameState.gameEnded === false) {
                 gameState.scoreText.x = 60


### PR DESCRIPTION
## Summary

The backend's old Heroku app (`rave-mom-app.herokuapp.com`) no longer exists and hadn't been deployed to since 2020. It's now live on Render + Neon at `https://rave-mom-api.onrender.com`. This updates the three hardcoded API URLs in `app.js` and the two in `gamescene.js` to point at the new host.

## Why

Verified end-to-end in browser: signed up and logged in against the live Render backend from a local copy of this frontend with these exact URL changes, confirmed the game loads and the leaderboard reads real scores back from Neon's Postgres.

## Test plan
- [x] Manually verified in browser: signup, login, and leaderboard all work against `https://rave-mom-api.onrender.com`.
