### PR TITLE
Add Claude Code config and spec template

### DIFF
--- a/.claude/commands/commit-message.md
+++ b/.claude/commands/commit-message.md
@@ -1,0 +1,41 @@
+---
+description: Create a commit message by analyzing git diffs
+allowed-tools: Bash(git status:*), Bash(git diff --staged), Bash(git commit:*)
+---
+
+## Context:
+
+- Current git status: !`git status`
+- Current git diff: !`git diff --staged`
+
+## Your task:
+
+Analyze above staged git changes and create a commit message. Use present tense and explain "why" something has changed, not just "what" has changed.
+
+## Commit types with emojis:
+Only use the following emojis:
+
+- ✨ `feat:` - New feature
+- 🐛 `fix:` - Bug fix
+- 🔨 `refactor:` - Refactoring code
+- 📝 `docs:` - Documentation
+- 🎨 `style:` - Styling/formatting
+- ✅ `test:` - Tests
+- ⚡ `perf:` - Performance
+
+## Format:
+
+Use the following format for making the commit message:
+
+```
+<emoji> <type>: <concise_descriptiom>
+<optional_body_explaining_why>
+```
+
+## Output:
+
+1. Show summary of changes currently staged
+2. Propose commit messages with appropriate emoji
+3. Ask for confirmation before commiting
+
+DO NOT auto-commit - wait for user approval, and only commit if user says so.

--- a/.claude/commands/spec.md
+++ b/.claude/commands/spec.md
@@ -1,0 +1,67 @@
+---
+description: Create a feature spec file and branch from a short idea
+argument-hint: Short feature description
+allowed-tools: Read, Write, Glob, Bash(git switch:*)
+---
+
+You are helping to spin up a new feature spec for this application, from a short idea provided in the user input below. Always adhere to any rules or requirements set out in any CLAUDE.md files when responding.
+
+User input: $ARGUMENTS
+
+## High level behavior
+
+Your job will be to turn the user input above into:
+
+- A human friendly feature title in kebab-case (e.g. new-heist-form)
+- A safe git branch name not already taken (e.g. claude/feature/new-heist-form)
+- A detailed markdown spec file under the _specs/ directory
+
+Then save the spec file to disk and print a short summary of what you did.
+
+## Step 1. Check the current branch
+
+Check the current Git branch, and abort this entire process if there are any uncommitted, unstaged, or untracked files in the working directory. Tell the user to commit or stash changes before proceeding, and DO NOT GO ANY FURTHER.
+
+## Step 2. Parse the arguments
+
+From `$ARGUMENTS`, extract:
+
+1. `feature_title`  
+   - A short, human readable title in Title Case.  
+   - Example: "Card Component for Dashboard Stats".
+
+2. `feature_slug`  
+   - A git safe slug.  
+   - Rules:  
+     - Lowercase 
+     - Kebab-case 
+     - Only `a-z`, `0-9` and `-`  
+     - Replace spaces and punctuation with `-`  
+     - Collapse multiple `-` into one  
+     - Trim `-` from start and end  
+     - Maximum length 40 characters  
+   - Example: `card-component` or `card-component-dashboard`.
+
+3. `branch_name`  
+   - Format: `claude/feature/<feature_slug>`  
+   - Example: `claude/feature/card-component`.
+
+If you cannot infer a sensible `feature_title` and `feature_slug`, ask the user to clarify instead of guessing.
+
+## Step 3. Switch to a new Git branch
+
+Before making any content, switch to a new Git branch using the `branch_name` derived from the `$ARGUMENTS`. If the branch name is already taken, then append a version number to it: e.g. `claude/feature/card-component-01`
+
+## Step 4. Draft the spec content
+
+Create a markdown spec document that Plan mode can use directly and save it in the _specs folder using the `feature_slug`. Use the exact structure as defined in the spec template file here: @_specs/template.md. Do not add technical implementation details such as code examples.
+
+## Step 5. Final output to the user
+
+After the file is saved, respond to the user with a short summary in this exact format:
+
+Branch: <branch_name>
+Spec file: specs/<feature_slug>.md
+Title: <feature_title>
+
+Do not repeat the full spec in the chat output unless the user explicitly asks to see it. The main goal is to save the spec file and report where it lives and what branch name to use.

--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "WebFetch"
+    ]
+  }
+}

--- a/_specs/template.md
+++ b/_specs/template.md
@@ -1,0 +1,18 @@
+# Spec for <feature-name>
+
+branch: claude/feature/<feature-name>
+
+## Summary
+...
+
+## Functional Requirements
+- ...
+
+## Possible Edge Cases
+- ...
+
+## Acceptance Criteria
+- ...
+
+## Open Questions
+- ...


### PR DESCRIPTION
## Summary
- Adds `.claude/settings.local.json` (local permissions) and custom slash commands (`commit-message`, `spec`)
- Adds `_specs/template.md`, the spec template used by the `/spec` workflow

## Test plan
- N/A — config/tooling only, no app behavior changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)