### PR TITLE
Exclude _specs and _plans from Firebase Hosting

### DIFF
--- a/firebase.json
+++ b/firebase.json
@@ -4,7 +4,9 @@
     "ignore": [
       "firebase.json",
       "**/.*",
-      "**/node_modules/**"
+      "**/node_modules/**",
+      "_specs/**",
+      "_plans/**"
     ]
   }
 }


### PR DESCRIPTION
## Summary

`firebase.json` uses `public: "."`, so every non-dotfile in the repo root gets served. That swept up the planning docs added alongside the login/signup split — today's deploy put `_specs/` and `_plans/` on the public site.

Nothing sensitive is in them, and the repo is public on GitHub regardless. But the site has no reason to serve internal planning docs, so this adds both to the hosting `ignore` list.

```diff
   "ignore": [
     "firebase.json",
     "**/.*",
-    "**/node_modules/**"
+    "**/node_modules/**",
+    "_specs/**",
+    "_plans/**"
   ]
```

## Files this covers

```
_plans/separate-login-signup-page.md
_specs/separate-login-signup-page.md
_specs/template.md
```

`CLAUDE.md` and `README.md` are deliberately left served — a public README is normal, and `CLAUDE.md` was scoped out of this change.

## Test plan

- [x] `firebase.json` parses as valid JSON
- [x] `_specs/**` and `_plans/**` match exactly the three files above
- [x] No other config key touched — the diff is two added array entries

**Not yet verified:** the exclusion takes effect only on the next `firebase deploy`. Hosting releases replace the entire file set, so a redeploy will drop these paths (currently `200`, expected `404` afterward). That hasn't been run from this branch, so the live site still serves them until someone deploys post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)