### PR TITLE
✨ feat: split the leaderboard onto its own page

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,7 +10,7 @@ Live site: https://rave-mom.firebaseapp.com/
 
 ## Running the project
 
-There is no build step, bundler, or package manager (no `package.json`). This is plain static HTML/CSS/JS loaded via `<script>` tags across two pages — `login.html` (signup/login) and `index.html` (game/leaderboard) — with Phaser 3 pulled from a CDN.
+There is no build step, bundler, or package manager (no `package.json`). This is plain static HTML/CSS/JS loaded via `<script>` tags across three pages — `login.html` (signup/login), `index.html` (game), and `leaderboard.html` (top-ten scores) — with Phaser 3 pulled from a CDN.
 
 To run locally:
 1. Also clone and run the backend, `rave-mom-api` — `bundle install` then `rails s`.
@@ -25,13 +25,21 @@ Hosted on Firebase Hosting (`firebase.json`, `.firebaserc`, project `rave-mom`).
 ## Architecture
 
 ### Frontend/backend split
-All game logic and UI live here; all persistence (users, auth tokens, scores) lives in the Rails API. The frontend talks to the backend over hardcoded URLs (e.g. `https://rave-mom-api.onrender.com/api/v1/users`, `/login`, `/scores`) — there's no env-based config, so backend URL changes require editing `login.js`, `dashboard.js`, and `gamescene.js` directly (`gamescene.js` re-declares `scoresURL` inline in each of its two bomb handlers).
+All game logic and UI live here; all persistence (users, auth tokens, scores) lives in the Rails API. The frontend talks to the backend over hardcoded URLs (e.g. `https://rave-mom-api.onrender.com/api/v1/users`, `/login`, `/scores`) — there's no env-based config, so backend URL changes require editing `login.js`, `leaderboard.js`, and `gamescene.js` directly (`gamescene.js` re-declares `scoresURL` inline in each of its two bomb handlers).
 
-Auth state is kept client-side in `localStorage` (`token`, `user_id`, `username`, `password`). Which page you're on determines how that state is treated: `login.js` clears all of `localStorage` on every load, so a fresh visit to the login page always starts clean; `index.html`'s scripts only ever *read* it, and clear it only on logout before navigating back to `login.html`. Requests to protected endpoints send `Authorization: bearer <token>`.
+Auth state is kept client-side in `localStorage` (`token`, `user_id`, `username`, `password`). Which page you're on determines how that state is treated: `login.js` clears all of `localStorage` on every load, so a fresh visit to the login page always starts clean; the scripts on `index.html` and `leaderboard.html` only ever *read* it, and clear it only on logout before navigating back to `login.html`. Requests to protected endpoints send `Authorization: bearer <token>`.
 
 ### Page split & session flow
 - `login.html` — signup and login forms only. A successful login stores the session in `localStorage` and then does a real navigation (`window.location.href`) to `index.html`. Signup deliberately does *not* auto-navigate; it shows an inline message and requires a separate manual login.
-- `index.html` — game and leaderboard only. `session-guard.js` redirects back to `login.html` if there's no valid session.
+- `index.html` — the game only. `session-guard.js` redirects back to `login.html` if there's no valid session.
+- `leaderboard.html` — top-ten scores only, with a "Return to Game" button. Also guarded by `session-guard.js`. It deliberately does *not* load `login.js`, which would clear the session on load.
+
+Navigating to the leaderboard unloads Phaser and discards an in-progress game, so the Leaderboard button is only offered after a game over — see the button visibility handoff below.
+
+### Stylesheets
+One shared stylesheet plus one per page; each page loads exactly two. `shared.css` holds the Google Fonts `@import` (which must stay the first rule in the file or CSS ignores it), the `*` reset, `body/html`, button and form-field styling, and the `.panel` sizing shared by the dashboard, canvas, and leaderboard. `login.css`, `game.css`, and `leaderboard.css` hold only their own page's rules.
+
+The `.panel` custom properties in `shared.css` are derived from the canvas's *outer* box (the 518x632 bitmap in `game.js` plus its border), so the dashboard and leaderboard match the canvas without the canvas itself being scaled — scaling it would blur the pixel art.
 
 ### Script load order (in `index.html`)
 Global scripts, no modules/bundler — load order matters and all state hangs off the global `gameState` object defined in `game.js`:
@@ -40,11 +48,18 @@ Global scripts, no modules/bundler — load order matters and all state hangs of
 3. `startmenu.js` — defines `StartMenu` Phaser scene (title screen, click-to-start)
 4. `gamescene.js` — defines `GameScene` Phaser scene (all core gameplay)
 5. `game.js` — creates `gameState` and the Phaser `Game` instance with `scene: [StartMenu, GameScene]`
-6. `dashboard.js` — welcome message, logout, leaderboard fetch/render. Declared in `<head>` but `defer`red, so it runs *after* the plain body scripts above, exactly where the old `app.js` used to run.
+6. `dashboard.js` — welcome message, logout, and navigation to the leaderboard. Declared in `<head>` but `defer`red, so it runs *after* the plain body scripts above.
 
-Note that steps 2–5 are plain body `<script>` tags: they execute synchronously during parsing, and therefore before any deferred `<head>` script. `gamescene.js` reaches across this shared global scope for `dashboard.js`'s top-level `leaderboard` and `scoresURL` bindings in its restart handler, so those two declarations must stay top-level and keep those exact names.
+Note that steps 2–5 are plain body `<script>` tags: they execute synchronously during parsing, and therefore before any deferred `<head>` script.
 
-`login.html` has no such subtlety — it loads only `login.js`, deferred.
+`login.html` and `leaderboard.html` have no such subtlety — each loads a single deferred script (`login.js` / `leaderboard.js`), with `session-guard.js` first and blocking on the latter.
+
+### Game-over button visibility
+The Leaderboard and Log Out buttons are hidden during play and revealed after a game over. The buttons live in `index.html`'s dashboard markup, but only `GameScene` knows when the game ended, so the handoff goes through a `game-over` class on `<body>`: `gamescene.js` adds it, `game.css` decides what it means. Neither script touches the other's scope.
+
+Two details are load-bearing:
+- The reveal hangs off `gameState.playerloses.once('animationrepeat', ...)`, **not** `animationcomplete`. The `playerloses` animation is created with `repeat: -1`, so it never completes and `animationcomplete` would never fire; `animationrepeat` fires when the first loop ends.
+- `game.css` uses `visibility: hidden` rather than `display: none`, so the hidden buttons still reserve their space and the dashboard doesn't shift when they appear.
 
 ### Game grid & bomb system (`gamescene.js`)
 This is the most complex part of the codebase and the most likely place for future changes:

--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ How to start game:
 2. Run "bundle install" to install the appropriate gems.
 3. Run the rails server using the command "rails s" and run the front end using lite-server or equivalent.
 
+The front end is three static pages: `login.html` (signup and login), `index.html` (the game), and `leaderboard.html` (top ten scores).
+
 Rave Mom is hosted on Google Firebase here => https://rave-mom.firebaseapp.com/
 
 Built With:

--- a/_plans/separate-leaderboard-page.md
+++ b/_plans/separate-leaderboard-page.md
@@ -1,0 +1,116 @@
+# Plan: Separate the leaderboard into its own page
+
+## Context
+
+`#game-container` is a flex **row** (`game.css:76-84`), and `#leaderboard-container` is `display: none` until the Leaderboard button sets it to `block` (`game.css:159-165`, `dashboard.js:19`). So opening the leaderboard doesn't overlay anything — it drops a third 30%-wide column inline beside the dashboard and canvas, squeezing the game. That crowding is the problem this solves.
+
+Per `_specs/separate-leaderboard-page.md`, the leaderboard moves to its own page and the button navigates instead of expanding a panel. Because navigating away unloads Phaser, the button is only offered after a game over — and Log Out follows the same rule, so no buttons show during play. The dashboard, canvas, and leaderboard panels are all squared to one size, and today's single `game.css` splits per page.
+
+This also removes real duplication: leaderboard fetch/render exists in `dashboard.js:34-60` **and** again inside `gamescene.js`'s `create()` (`gamescene.js:601-622`), with `gamescene.js:412-414` reaching across global scope for `dashboard.js`'s `leaderboard` and `scoresURL` bindings. With no leaderboard on the game page, that in-game copy is deleted rather than shared.
+
+### Decisions locked in (from the spec's answered questions)
+
+- Page is `leaderboard.html`; panel **centered**; list **scrolls** inside the panel if it overruns.
+- Buttons appear **after the first full knocked-out animation loop**, and reserve their space while hidden.
+- Existing Close button becomes **"Return to Game"** — the page's only control (no welcome message, no logout).
+- Failed/unauthorized/empty score fetch → **render an empty list**, no error UI, but must not throw.
+- Stylesheets: `shared.css` + `login.css` + `game.css` (narrowed) + `leaderboard.css`.
+- Plain top-ten list; no player rank. `index.html` keeps its filename.
+
+## Critical existing behavior to preserve
+
+1. **`playerloses` loops forever.** `gamescene.js:296-301` sets `repeat: -1`, so `animationcomplete` never fires on it. Use `gameState.playerloses.once('animationrepeat', …)`, which fires the instant the first cycle ends (~1.3s at 4 frames / frameRate 3). Animation config stays unchanged. **Verify the event name fires under Phaser 3.16.2 in the browser**; if it doesn't, fall back to `this.time.delayedCall(1333, …)`.
+2. **The global-scope handoff must be cut in one step.** `gamescene.js:412-414` reads `leaderboard` and `scoresURL` from `dashboard.js`'s top-level scope. Deleting `dashboard.js`'s leaderboard code without simultaneously deleting `gamescene.js`'s restart-refresh throws `ReferenceError` on every restart. Both edits land together.
+3. **Each bomb handler declares its own local `scoresURL`** (`gamescene.js:319` and `:364`) for the score POST. Those are independent of the global and **stay**.
+4. **`session-guard.js` must stay a plain, non-deferred, first-in-`<head>` script** on both `index.html` and the new `leaderboard.html` — that's what prevents a content flash before redirect.
+5. **`login.js:5` calls `localStorage.clear()` on load.** `leaderboard.html` must never load `login.js`, or viewing the leaderboard logs the user out.
+6. **`@import` of Press Start 2P (`game.css:1`) must be the first rule in `shared.css`** — CSS ignores `@import` that isn't at the top. The universal `* { background-color: black }` (`game.css:3-6`) also belongs in `shared.css`; a lot of the look depends on it.
+7. **Phaser scopes pointer input to the canvas**, so the DOM buttons shouldn't trigger the click-to-play-again handler at `gamescene.js:406`. Confirm during verification.
+8. `#canvas-container` is Phaser's render parent (`game.js:9`) and currently has **no CSS rules at all**.
+
+## File changes
+
+### New: `leaderboard.html`
+Mirrors `index.html`'s head contract — `session-guard.js` as the literal first tag (plain, not deferred), then `shared.css`, `leaderboard.css`, favicon, and `leaderboard.js` deferred. Body holds the `#leaderboard-container` block moved from `index.html:38-47`, with `#leaderboard-close` becoming `#return-to-game` labelled "Return to Game". No Phaser scripts, no `login.js`.
+
+### New: `leaderboard.js`
+Move the render logic out of `dashboard.js:34-60` — `parseJSON`, `displayScores`, `topTenScores`, `appendScore`, `clearLeaderboard` — plus its own `scoresURL` and the auth-header fetch from `dashboard.js:20-27`. Drop `displayScores`'s `leaderboardButton.style.display = "none"` line (no such button here). Return-to-game handler navigates to `index.html`.
+
+**Guard the response shape.** An unauthorized or errored request returns an object, not an array, and `topTenScores` calls `.sort()` on it — that throws. Normalize with an `Array.isArray()` check plus a `.catch()`, both resolving to an empty list. This is what makes the "empty list, never throws" requirement actually hold.
+
+### Modified: `index.html`
+Delete the `#leaderboard-container` block (lines 38-47). Swap the stylesheet link for `shared.css` + `game.css`.
+
+### Modified: `dashboard.js`
+Keep the welcome message and logout. Point the Leaderboard button at `leaderboard.html` instead of revealing a panel. Delete `leaderboardContainer`, `leaderboardClose`, the top-level `leaderboard` and `scoresURL` consts, and every render helper — the file drops to roughly its first 15 lines plus the two navigation handlers.
+
+### Modified: `gamescene.js`
+- Delete the leaderboard refresh inside the restart handler (`gamescene.js:411-421`), keeping `gameState.score = 0` and `this.scene.restart()`.
+- Delete the duplicated helpers at `gamescene.js:601-622`.
+- Add a local `revealGameOverButtons()` in `create()` that does `document.body.classList.add('game-over')`, and call it from a `gameState.playerloses.once('animationrepeat', …)` registered right after each `anims.play('playerloses', true)` (`:352` and `:397`). A single local helper avoids a third copy-paste across the two symmetric bomb handlers.
+- In the restart handler, `document.body.classList.remove('game-over')`.
+
+Toggling a body class — rather than calling into another script — is the "defined hand-off" the spec asks for: no shared globals, no load-order coupling, and it survives `scene.restart()` cleanly.
+
+### Modified: CSS — split `game.css` four ways
+
+| File | Contents |
+|---|---|
+| `shared.css` | `@import` (first line), `*` reset, `body, html`, `.button`, `.button-container`, `.form-field`, panel sizing |
+| `login.css` | `#nav-card-container`, `#nav-card`, `.nav-bar-member`, `form`, `h2`, `.form-title`, `#sign-up-message` |
+| `game.css` | `#game-container`, `#dashboard`, `#welcome-message`, `.rule-container`, `.rules`, `canvas`, button visibility |
+| `leaderboard.css` | `#leaderboard*` rules, centering, scroll |
+
+**Panel sizing** — declare once in `shared.css` and apply to `#dashboard`, `#canvas-container`, and `#leaderboard-container`:
+
+```css
+:root { --panel-w: 518px; --panel-h: 632px; }   /* matches game.js:7-8 */
+```
+
+To make the two columns actually line up: drop `padding-top: 50px` from the `canvas` rule (`game.css:149`) and `#dashboard`'s `margin-top: 100px` / `margin-bottom: 50px`, then set `#game-container { align-items: center; }`. Otherwise the canvas's padding pushes it 50px past a 632px-tall box. **Exact pixel reconciliation needs eyeballing in the browser** — borders and `box-sizing: border-box` (`game.css:4`) both affect the final box.
+
+**Button visibility** — `visibility: hidden` rather than `display: none`, which is what reserves their space:
+
+```css
+#user-logout, #leaderboard-button { visibility: hidden; }
+body.game-over #user-logout,
+body.game-over #leaderboard-button { visibility: visible; }
+```
+
+**Leaderboard scroll** — make `#leaderboard-container` a flex column and give the `#leaderboard` `<ul>` `flex: 1; overflow-y: auto;` so the title and Return to Game button stay pinned while only the list scrolls. Also drop the dead `#leaderboard-update` rule (`game.css:190-192`) — no such element exists.
+
+### Modified: `login.html`
+Stylesheet link becomes `shared.css` + `login.css`. Nothing else changes.
+
+### Modified: docs
+- `session-guard.js:1` — comment says "Runs before anything else on index.html"; it now guards two pages.
+- `CLAUDE.md` — three-page structure, the stylesheet split, and (importantly) delete the note that `gamescene.js` depends on `dashboard.js`'s `leaderboard`/`scoresURL` globals, since this work removes exactly that. Document the `body.game-over` handoff.
+- `README.md` — one line noting the three pages; it currently documents no file structure at all.
+
+### No change
+`game.js`, `startmenu.js`, `firebase.json` (no rewrites exist, so `/leaderboard.html` is served directly), and the score POST in both bomb handlers.
+
+## Verification
+
+Backend must be running (`rails s` in `rave-mom-api`); serve this repo statically (`python3 -m http.server 8000`) — no build step.
+
+1. Clear `localStorage`, visit `/` → redirect to `login.html`, no game flash.
+2. Log in → game page. **No buttons visible** in the dashboard, only welcome message and rules.
+3. Confirm dashboard and canvas are the same width and height and aligned top and bottom.
+4. Play; verify no buttons appear mid-game and the canvas is full width with no third column.
+5. Die → score POSTs; the knocked-out sprite keeps looping; **both buttons appear after ~1.3s**. Confirm surrounding content doesn't shift when they appear (the reserved-space check).
+6. Click Leaderboard → `leaderboard.html`, panel centered, same size as the game, top ten rendered.
+7. Return to Game → back to `index.html`, lands on the start menu.
+8. Die again, click to play again instead → buttons hide, new game starts, **no `ReferenceError` in console** (highest-risk regression: the `leaderboard`/`scoresURL` global cut).
+9. Repeat death/restart 3+ times → buttons toggle correctly each cycle.
+10. Click a button right after death → confirm it does *not* also trigger click-to-play-again.
+11. Stop the backend, reload `leaderboard.html` → empty list, no unhandled console error. Repeat with a corrupted `token`.
+12. Visit `leaderboard.html` with `localStorage` cleared → redirect to login, no content flash.
+13. Log out from the game page → back to `login.html`; confirm login page still looks unchanged after the CSS split.
+14. Confirm the pixel font loads on all three pages (the `@import`-position check).
+
+## Risks
+
+- **`animationrepeat` not firing under Phaser 3.16.2** — the one unverified assumption. Fallback is `this.time.delayedCall`. Check first; it gates the whole button-reveal design.
+- **CSS cascade drift from the split** — rules that only worked because of their position in one file. Steps 3, 13, 14 are the guards.
+- **Panel sizing** is the most likely thing to need visual iteration; the numbers above are a starting point, not a final answer.

--- a/_specs/separate-leaderboard-page.md
+++ b/_specs/separate-leaderboard-page.md
@@ -1,0 +1,107 @@
+# Spec for separate-leaderboard-page
+
+branch: claude/feature/separate-leaderboard-page
+
+## Summary
+The game page is crowded. `#game-container` lays its children out in a row, so opening the leaderboard adds a third 30%-wide column inline beside the dashboard and the canvas, squeezing the game rather than overlaying it. This spec covers moving the leaderboard onto its own page, so the game page holds only the dashboard and the canvas, and the Leaderboard button navigates to the leaderboard instead of expanding a panel in place.
+
+Because navigating away unloads Phaser and discards an in-progress game, the Leaderboard button is only offered after a game over — it is hidden on the start menu and during active play, and appears once the knocked-out animation has finished. The Log Out button follows the same rule, so the dashboard shows no buttons at all while a game is live. The dashboard column is also squared up to match the game canvas in both width and height, and the leaderboard's panel on its new page adopts those same dimensions, so every panel across the site is one consistent size. How any of this behaves as the window is resized is deliberately out of scope and will be handled in a later spec.
+
+Doing this also resolves duplication that exists today: leaderboard fetch-and-render logic lives both at the top level of `dashboard.js` and again as near-identical private copies inside `gamescene.js`'s `create()`, and `gamescene.js` reaches across global scope for `dashboard.js`'s `leaderboard` and `scoresURL` bindings in order to refresh the panel on click-to-play-again. With the panel gone from the game page, that in-game leaderboard code is removed rather than shared.
+
+Alongside the page split, the single `game.css` stylesheet — which currently serves both `login.html` and `index.html`, holding auth rules and game rules together — is split into a shared `shared.css` plus one stylesheet per page, so each page loads the shared base styles plus only its own rules. Beyond the button visibility rules and the dashboard size match, no redesign of the dashboard's welcome message, rules, or button styling is in scope.
+
+## Functional Requirements
+- A new `leaderboard.html` page is created, showing the same top-ten scores the current panel shows, fetched from the same backend endpoint with the same authorization header.
+- The leaderboard stays a plain top-ten list as it is today; showing the signed-in player's own score or rank is explicitly deferred to a later change.
+- The leaderboard's container on its own page uses the same dimensions as the game canvas, matching the dashboard, so all three panels across the site are the same size rather than the leaderboard being a narrow side column or a full-bleed page.
+- The leaderboard panel is centered on its page, rather than sitting in the left-hand position the dashboard occupies on the game page.
+- Because the dashboard, the canvas, and the leaderboard now share one set of dimensions, that sizing is expressed once in the shared stylesheet rather than repeated per page.
+- If the score list is taller than the shared panel height, the list scrolls within the panel; the panel itself does not grow beyond the shared dimensions.
+- The Leaderboard button on the game page navigates to the leaderboard page instead of revealing an inline panel.
+- The Leaderboard button is hidden when the game page first loads and stays hidden through the start menu and active gameplay.
+- The Leaderboard button becomes visible once the player's knocked-out animation has finished playing, not at the instant of death.
+- The Leaderboard button is hidden again when the player restarts, so it is never available during a live game.
+- The Log Out button follows the same visibility rules as the Leaderboard button: hidden on load, through the start menu, and during active play, shown once the knocked-out animation finishes, and hidden again on restart.
+- While a game is live the dashboard therefore shows no buttons at all, leaving only the welcome message and the rules.
+- Both buttons reserve their space in the dashboard while hidden, so the surrounding content stays put rather than re-centering when they appear and disappear.
+- The existing game-over prompt text is left as it is; the buttons appearing is the only new signal.
+- Because both buttons live in the dashboard markup while the game-over state is owned by the game scene, showing and hiding them requires a defined hand-off between the scene and the page chrome, rather than the scene reaching into another script's globals as it does today.
+- The dashboard column's height matches the height of the game canvas, with their tops and bottoms aligned, rather than the two columns running to unrelated heights as they do today.
+- The dashboard column's width matches the width of the game canvas, replacing its current percentage-based width, so the two columns are equally sized.
+- The dashboard's dimensions stay fixed to the canvas regardless of how many buttons are currently visible, so the column does not grow, shrink, or shift the canvas when the buttons appear on game over and disappear on restart.
+- Responsive and resize behavior is explicitly out of scope for this spec: the dashboard and canvas need to match at the normal desktop viewport the game is played at, and how the pairing degrades on smaller or resized windows is deferred to a later spec.
+- The panel's existing Close button becomes a "Return to Game" button that navigates back to the game page; that button is the leaderboard page's only control, with no welcome message or Log Out button on the page.
+- The inline leaderboard markup is removed from the game page, so the game page renders only the dashboard column and the canvas, and the canvas is no longer competing with a third column for width.
+- The leaderboard fetch, sort, top-ten trim, list render, and list clear logic lives in exactly one place, used by the leaderboard page.
+- The duplicated leaderboard helper functions inside `gamescene.js`'s `create()` are removed, along with the click-to-play-again leaderboard refresh, since there is no longer a leaderboard on the game page to refresh.
+- `gamescene.js` no longer depends on `dashboard.js` declaring top-level `leaderboard` and `scoresURL` bindings with those exact names.
+- `dashboard.js` retains its welcome message and logout responsibilities, with its leaderboard fetch/render/close responsibilities removed.
+- Restarting after a game over continues to work: score resets, the scene restarts, and the player can play again.
+- Score submission on game over continues to POST to the backend exactly as it does today.
+- The leaderboard page is session-protected the same way the game page is: visiting it without a valid session redirects to the auth page, without a flash of leaderboard content.
+- The leaderboard page does not clear `localStorage` on load — that behavior belongs only to the auth page.
+- If the scores request fails, returns unauthorized, or returns nothing, the page renders an empty list rather than an error state; dedicated error and empty-state messaging is deferred to a later change. It must not throw an unhandled error or leave the page broken.
+- Today's `game.css` is split into `shared.css`, holding rules common to all pages (page/body basics, background, the shared panel dimensions, button styling, form fields, the pixel typography), plus one stylesheet per page.
+- The page stylesheets are `login.css` for `login.html`, `game.css` for the game page, and `leaderboard.css` for `leaderboard.html`. `game.css` keeps its name but narrows to game-page rules only, and is deliberately named for the page's role rather than its `index.html` filename.
+- Each page loads only the shared stylesheet plus its own page stylesheet; no page pulls in rules for a page it isn't.
+- Both existing pages render visually the same as they do today after the stylesheet split, apart from the game page no longer having a leaderboard column.
+- Logging out continues to return the user to the auth page.
+
+## Possible Edge Cases
+- A player who dies, views the leaderboard, and returns to the game lands on the start menu rather than the game-over prompt, and their score display resets.
+- The player dies, the button appears, and they click to play again instead of viewing the leaderboard — the button must disappear rather than linger into the new game.
+- The player dies and the button appears, then the page sits idle before they click anything.
+- Clicking the Leaderboard button must not also register as the click-to-play-again input; the button sits in the DOM outside the canvas, so this depends on the game's pointer handling staying scoped to the canvas.
+- Repeated death-and-restart cycles in a single page load, with both buttons toggling visibility each time.
+- With both buttons hidden during play, there is no way to log out mid-game — the player has to finish a game first. This is the intended consequence of the rule, but it means a player who wants to leave must either die or reload the page.
+- Any styling that assumes the buttons are always present in the dashboard column, given they now start hidden while still occupying their space.
+- The knocked-out animation may already have a completion handler in the game-over path; hooking button reveal to it must not disturb the existing restart wiring or fire twice across repeated deaths.
+- The game canvas is a fixed 518x632 with padding and a border, while the dashboard sits in a full-height flex row with its own margins and border, so matching the two has to account for each one's padding and borders rather than just the canvas's configured pixel size.
+- The rules text is currently sized for a percentage-width column; at a fixed width matched to the canvas it may wrap differently or run taller than it does today.
+- Sizing the dashboard to the canvas at the normal desktop viewport may look wrong at other window sizes — accepted for this spec, and deferred to the follow-up spec on resize behavior.
+- The leaderboard page loaded directly by URL, bookmark, or a second tab without a valid session.
+- A stale or expired token in `localStorage` when the leaderboard page fetches scores — the session guard only checks that a token exists, so an expired one still reaches the fetch and comes back unauthorized. Empty list is the accepted outcome for now, but it must not throw.
+- The scores request failing or the backend being cold/slow (the API is hosted on a free tier that sleeps) — the page shows an empty list, which is indistinguishable from there being no scores. Accepted for this pass.
+- Zero scores returned, or fewer than ten scores — the page should still render sensibly.
+- Splitting one stylesheet into several can change cascade or specificity outcomes if the link order across the new files doesn't preserve the original rule order.
+- Rules that currently only apply because both pages loaded the same file may be dropped from a page that still needs them, or duplicated into both shared and page stylesheets.
+- The leaderboard's existing styling assumes a narrow 30% column and a hidden-by-default container; it needs to become visible by default and sized to the shared panel dimensions.
+- Ten score entries in the pixel typeface, plus the title and the Return to Game button, may not fit inside a container fixed to the canvas's height — the list scrolls inside the panel when that happens, so the scroll region must be the list itself and not swallow the title or the button.
+- Scores with long usernames or large values may wrap or overflow horizontally now that the container is a fixed width rather than a percentage.
+- Browser back/forward navigation between the game page and the leaderboard page.
+- Returning visitors may have the old stylesheet cached.
+- Removing the leaderboard refresh from `gamescene.js` must not disturb the surrounding game-over and restart handling in the same block.
+
+## Acceptance Criteria
+- The game page never renders a leaderboard column; with the leaderboard gone, the dashboard and canvas are the only two columns, and the canvas is no longer squeezed.
+- Neither the Leaderboard nor the Log Out button is visible on page load, on the start menu, or at any point during a live game — the dashboard shows only the welcome message and rules while playing.
+- Both buttons appear once the knocked-out animation has finished, and both disappear again once the player clicks to play again, across repeated death-and-restart cycles.
+- The dashboard's content does not shift position when the buttons appear or disappear, because their space is reserved while hidden.
+- The dashboard column and the game canvas are the same width and the same height, and are aligned top and bottom.
+- The leaderboard panel is centered on `leaderboard.html`, is the same size as the dashboard and the canvas, and a full top-ten list is legible within it — scrolling inside the panel if the list runs long, with the title and Return to Game button staying visible.
+- The dashboard's dimensions and the canvas's position do not shift when the buttons appear or disappear.
+- These layout criteria are judged at a normal desktop viewport; behavior at other window sizes is not in scope.
+- Clicking Leaderboard after a game over navigates to the leaderboard page and shows the same top-ten scores the panel showed before this change.
+- The Return to Game button navigates back to the game page, and no welcome message or Log Out button appears on the leaderboard page.
+- With the backend unreachable or the token expired, the leaderboard page renders an empty list and throws no unhandled console errors.
+- Loading the leaderboard page without a valid session redirects to the auth page with no flash of content.
+- Full flow works end to end against the backend with no console errors: signup, login, redirect to the game, welcome message, gameplay, rave-girl scoring, laser death, score submission, the Leaderboard button appearing, navigating to the leaderboard and back, restart via click-to-play-again, and logout to the auth page.
+- Searching the codebase for the leaderboard fetch/sort/render logic finds it in exactly one file, and `gamescene.js` contains no leaderboard code.
+- No page loads CSS rules belonging to a different page, the stylesheets are `shared.css`, `login.css`, `game.css`, and `leaderboard.css`, and `game.css` no longer contains auth or leaderboard rules; the auth page and game page look the same as they do on `master` today, aside from the removed leaderboard column and the dashboard's new dimensions.
+- Sprites, background images, and the favicon load correctly on all three pages.
+- A `firebase deploy` from the repo root publishes all three pages and the deployed site behaves the same as the local one.
+- `README.md` and `CLAUDE.md` describe the three-page structure, the stylesheet split, and the script load order accurately.
+
+## Open Questions
+- What should the leaderboard page be named, and does anything outside the app need to know about it (hosting config, README, links)? leaderboard.html
+- Should the buttons appear instantly on death or after the knocked-out animation finishes, and should their appearance be called out in the game-over prompt text?  after knockout animation finishes
+- Should the hidden buttons reserve their space in the dashboard while invisible, or collapse so the dashboard's other content re-centers during play? reserve their space
+- With logout unavailable mid-game, is dying or reloading an acceptable way to leave, or should logout stay reachable some other way? We can address on future spec
+- Should the leaderboard page show the signed-in player's own score or rank alongside the top ten, or stay a plain top-ten list as today? stay in current list, we can add user's top score later
+- Should the leaderboard page carry the welcome message and logout button too, or only a link back to the game? Lets change the "close" button to a "return to game" button 
+- What should the leaderboard page show when the scores request fails, returns unauthorized, or returns an empty list? lets just do empty list for now
+- How should the stylesheets be named and organized — keep `game.css` for the game page and add siblings, or rename all of them under a consistent scheme? `shared.css` for common rules, then `login.css`, `game.css`, and `leaderboard.css` per page — `game.css` keeps its name even though its page is `index.html`
+- Should the leaderboard's panel sit centered on its page, or in the same position the dashboard occupies on the game page? centered on its page
+- If a full top-ten list overruns the shared panel height, should the list scroll inside the panel, or should spacing and type size be tightened to fit? lets implement a scroll in the panel
+- Page stylesheets are named after their HTML page, but the shared stylesheet has no page to name it after — what should it be called? shared.css

--- a/dashboard.js
+++ b/dashboard.js
@@ -1,11 +1,6 @@
 const welcomeMessage = document.querySelector("#welcome-message")
 const logOutButton = document.querySelector("#user-logout");
 const leaderboardButton = document.querySelector("#leaderboard-button");
-const leaderboardContainer = document.querySelector("#leaderboard-container");
-const leaderboardClose = document.querySelector("#leaderboard-close");
-const leaderboard = document.querySelector("#leaderboard")
-
-const scoresURL = "https://rave-mom-api.onrender.com/api/v1/scores"
 
 welcomeMessage.textContent = `Welcome ${localStorage.getItem("username")}`
 
@@ -15,46 +10,5 @@ logOutButton.addEventListener("click", event => {
 })
 
 leaderboardButton.addEventListener("click", event => {
-    clearLeaderboard(leaderboard);
-    leaderboardContainer.style.display = "block"
-    fetch(scoresURL, {
-        headers: {
-            "Authorization": `bearer ${localStorage.getItem("token")}`
-        }
-    })
-    .then(parseJSON)
-    .then(response => displayScores(response))
+    window.location.href = "leaderboard.html"
 })
-
-leaderboardClose.addEventListener("click", event => {
-    leaderboardContainer.style.display = "none"
-    leaderboardButton.style.display = "block"
-})
-
-function parseJSON(response) {
-    return response.json()
-}
-
-function displayScores(response) {
-    let topScores = topTenScores(response)
-    topScores.map(score => appendScore(score))
-    leaderboardButton.style.display = "none"
-}
-
-function topTenScores(scores) {
-    let sortedScores = scores.sort((a, b) => (b.score - a.score))
-    let topScores = sortedScores.slice(0, 10)
-    return topScores
-}
-
-function appendScore(score) {
-    let scoreItem = document.createElement('li')
-    scoreItem.innerHTML = `<h1>${score.user.username} ${score.score}</h1>`
-    leaderboard.appendChild(scoreItem)
-}
-
-function clearLeaderboard(leaderboard) {
-    while(leaderboard.firstChild) {
-        leaderboard.removeChild(leaderboard.firstChild);
-    }
-}

--- a/game.css
+++ b/game.css
@@ -1,116 +1,23 @@
-@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
-
-* {
-    box-sizing: border-box;
-    background-color: black;
-}
-
-#nav-card-container {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-    background-image: url("assets/images/IMG_2859.JPG");
-    background-position: center;
-    background-repeat: no-repeat;
-    background-size: cover;
-    height: 100%;
-}
-
-#nav-card {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    margin-top: 150px;
-    height: 60%;
-    width: 50%;
-    border-style: solid;
-    border-color: greenyellow;
-    border-radius: 10%;
-    list-style: none;
-    box-shadow: 10px 5px 5px white;
-}
-
-.nav-bar-member {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-}
-
-form {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-    width: 80%
-}
-
-h2 {
-    color: white;
-    font-family: 'Press Start 2P', cursive;
-}
-
-.form-title {
-    color: white;
-    font-family: 'Press Start 2P', cursive;
-}
-
-#sign-up-message {
-    color: white;
-    font-family: 'Press Start 2P', cursive;
-}
-
-.form-field {
-    background-color: white;
-}
+/* Styles for the game page (index.html) only. Shared rules live in shared.css. */
 
 #game-container {
     display: flex;
-    flex-direction: column;
-    align-items: center;
-}
-
-body, html {
-    height:100%;
-    background-color: black;
-}
-
-#game-container {
-    display: flex;
-    background-image: url("assets/images/IMG_2859.JPG");
     flex-direction: row;
     justify-content: space-evenly;
+    align-items: center;
     height: 100%;
+    background-image: url("assets/images/IMG_2859.JPG");
     background-position: center;
     background-repeat: repeat;
     background-size: cover;
 }
 
+/* Sized by .panel in shared.css so it matches the canvas exactly. */
 #dashboard {
     display: flex;
     flex-direction: column;
     justify-content: center;
-    margin-top: 100px;
-    margin-bottom: 50px;
     padding-bottom: 20px;
-    width: 30%;
-    border-style: solid;
-    border-color: greenyellow;
-}
-
-.button-container {
-    display: flex;
-    flex-direction: row;
-    justify-content: center;
-}
-
-.button {
-    align-items: center; 
-    background-color: white;
-    margin-top: 10px;
-    padding-top: 5px;
-    padding-bottom: 5px;
-    width: 60%;
-    font-size: 20px;
-    font-family: 'Press Start 2P', cursive;
 }
 
 #welcome-message {
@@ -120,14 +27,6 @@ body, html {
     color: white;
     font-family: 'Press Start 2P', cursive;
     align-items: center;
-}
-
-#rules-container {
-    display: none;
-    width: 40%;
-    margin-bottom: 30px;
-    border-style: solid;
-    border-color: greenyellow;
 }
 
 .rule-container {
@@ -144,53 +43,22 @@ body, html {
     font-size: 12pt;
 }
 
-
 canvas {
     display: block;
-    margin-top: 0;
-    margin-left: auto;
-    margin-right: auto;
-    margin-bottom: 0;
-    padding-top: 50px;
-    border-style: solid;
-    border-color: greenyellow;
+    margin: 0 auto;
+    border: var(--panel-border) solid var(--panel-border-color);
 }
 
-#leaderboard-container {
-    display: none;
-    width: 30%;
-    margin-bottom: 30px;
-    border-style: solid;
-    border-color: greenyellow;
+/* Both buttons stay hidden through the start menu and active play, and are
+   revealed once the knocked-out animation has looped: gamescene.js toggles
+   `game-over` on <body>. Using visibility rather than display keeps their
+   space reserved, so the dashboard's contents don't shift when they appear. */
+#user-logout,
+#leaderboard-button {
+    visibility: hidden;
 }
 
-#leaderboard {
-    width: 80%;
-    align-items: center;
-    list-style: none;
-}
-
-#leaderboard li{
-    color: white;
-    font-family: 'Press Start 2P', cursive;
-}
-
-#leaderboard-title-container {
-    display: flex;
-    flex-direction: column;
-    justify-content: center;
-}
-
-#leaderboard-title {
-    color: white;
-    font-family: 'Press Start 2P', cursive;
-    padding-left: 20px;
-}
-
-#leaderboard-update {
-    margin-bottom: 20px;
-}
-
-#leaderboard-close {
-    margin-bottom: 20px;
+body.game-over #user-logout,
+body.game-over #leaderboard-button {
+    visibility: visible;
 }

--- a/gamescene.js
+++ b/gamescene.js
@@ -350,6 +350,7 @@ class GameScene extends Phaser.Scene {
 
                 gameState.playerloses.x = playerX; gameState.playerloses.y = playerY;
                 gameState.playerloses.anims.play('playerloses', true);
+                gameState.playerloses.once('animationrepeat', revealGameOverButtons);
                 gameState.gameEndText.setText('CLICK TO PLAY AGAIN');
                 gameState.gameEnded = true;
 
@@ -395,6 +396,7 @@ class GameScene extends Phaser.Scene {
 
                 gameState.playerloses.x = playerX; gameState.playerloses.y = playerY;
                 gameState.playerloses.anims.play('playerloses', true);
+                gameState.playerloses.once('animationrepeat', revealGameOverButtons);
                 gameState.gameEndText.setText('CLICK TO PLAY AGAIN');
                 gameState.gameEnded = true;
 
@@ -407,17 +409,8 @@ class GameScene extends Phaser.Scene {
         this.input.on('pointerup', () => {
             if(gameState.gameEnded === true) {
                 gameState.score = 0;
+                hideGameOverButtons();
                 this.scene.restart();
-
-                clearLeaderboard(leaderboard);
-
-                fetch(scoresURL, {
-                    headers: {
-                        "Authorization": `bearer ${localStorage.getItem("token")}`
-                    }
-                })
-                .then(parseJSON)
-                .then(response => displayScores(response))
             }
         })
 
@@ -532,10 +525,6 @@ class GameScene extends Phaser.Scene {
             gameState.scoreText.setText(`SCORE: ${gameState.score}`);
         })
 
-        function parseJSON(response) {
-            return response.json()
-        }
-
         function isArrayInArray(arr, item) {
             var itemStr = JSON.stringify(item);
             var contains = arr.some(function(ele) {
@@ -598,29 +587,18 @@ class GameScene extends Phaser.Scene {
             }
         }
         
-        function clearLeaderboard(leaderboard) {
-            while(leaderboard.firstChild) {
-                leaderboard.removeChild(leaderboard.firstChild);
-            }
+        // The Leaderboard and Log Out buttons live in the dashboard markup, but
+        // only this scene knows when the game has ended. Toggling a class on
+        // <body> hands that off without either script reaching into the other's
+        // scope; game.css decides what the class means.
+        function revealGameOverButtons() {
+            document.body.classList.add('game-over');
         }
 
-        function displayScores(response) {
-            let topScores = topTenScores(response)
-            topScores.map(score => appendScore(score))
+        function hideGameOverButtons() {
+            document.body.classList.remove('game-over');
         }
-        
-        function topTenScores(scores) {
-            let sortedScores = scores.sort((a, b) => (b.score - a.score))
-            let topScores = sortedScores.slice(0, 10)
-            return topScores
-        }
-        
-        function appendScore(score) {
-            let scoreItem = document.createElement('li')
-            scoreItem.innerHTML = `<h1>${score.user.username} ${score.score}</h1>`
-            leaderboard.appendChild(scoreItem)
-        }
-        
+
     }
     
     update() {

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
     <script src="./session-guard.js"></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./shared.css">
     <link rel="stylesheet" href="./game.css">
     <link rel="shortcut icon" type="image/png" href="assets/icons/favicon.png"/>
     <script src="./dashboard.js" defer></script>
@@ -15,7 +16,7 @@
     <script src="./gamescene.js"></script>
     <script src="./game.js"></script>
     <section id="game-container">
-        <div id="dashboard">
+        <div id="dashboard" class="panel">
             <h1 id="welcome-message"></h1>
             <div class="rule-container">
                 <h3 class="rules">You are your squad's only hope! They need water!</h3>
@@ -34,16 +35,6 @@
             </div>
         </div>
         <div id="canvas-container">
-        </div>
-        <div id="leaderboard-container">
-            <div id="leaderboard-title-container">
-                <h1 id="leaderboard-title">Leaderboard:</h1>
-            </div>
-            <ul id="leaderboard">
-            </ul>
-            <div class="button-container">
-                <button class="button" id="leaderboard-close">Close</button>
-            </div>
         </div>
     </section>
 </body>

--- a/leaderboard.css
+++ b/leaderboard.css
@@ -1,0 +1,51 @@
+/* Styles for leaderboard.html only. Shared rules live in shared.css. */
+
+#leaderboard-page {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    align-items: center;
+    height: 100%;
+    background-image: url("assets/images/IMG_2859.JPG");
+    background-position: center;
+    background-repeat: repeat;
+    background-size: cover;
+}
+
+/* Sized by .panel in shared.css so it matches the game canvas. */
+#leaderboard-container {
+    display: flex;
+    flex-direction: column;
+    padding-bottom: 20px;
+}
+
+#leaderboard-title-container {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+}
+
+#leaderboard-title {
+    color: white;
+    font-family: 'Press Start 2P', cursive;
+    padding-left: 20px;
+}
+
+/* Only the list scrolls, so the title and Return to Game button stay put
+   even when a full top ten overruns the panel height. */
+#leaderboard {
+    flex: 1;
+    overflow-y: auto;
+    margin: 0 auto 10px auto;
+    width: 80%;
+    list-style: none;
+}
+
+#leaderboard li{
+    color: white;
+    font-family: 'Press Start 2P', cursive;
+}
+
+#return-to-game {
+    margin-bottom: 20px;
+}

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -1,0 +1,27 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <script src="./session-guard.js"></script>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="./shared.css">
+    <link rel="stylesheet" href="./leaderboard.css">
+    <link rel="shortcut icon" type="image/png" href="assets/icons/favicon.png"/>
+    <script src="./leaderboard.js" defer></script>
+    <title>Rave Mom</title>
+</head>
+<body>
+    <section id="leaderboard-page">
+        <div id="leaderboard-container" class="panel">
+            <div id="leaderboard-title-container">
+                <h1 id="leaderboard-title">Leaderboard:</h1>
+            </div>
+            <ul id="leaderboard">
+            </ul>
+            <div class="button-container">
+                <button class="button" id="return-to-game">Return to Game</button>
+            </div>
+        </div>
+    </section>
+</body>
+</html>

--- a/leaderboard.js
+++ b/leaderboard.js
@@ -1,0 +1,47 @@
+const leaderboard = document.querySelector("#leaderboard")
+const returnToGameButton = document.querySelector("#return-to-game")
+
+const scoresURL = "https://rave-mom-api.onrender.com/api/v1/scores"
+
+returnToGameButton.addEventListener("click", event => {
+    window.location.href = "index.html"
+})
+
+fetch(scoresURL, {
+    headers: {
+        "Authorization": `bearer ${localStorage.getItem("token")}`
+    }
+})
+.then(parseJSON)
+.then(displayScores)
+.catch(() => displayScores([]))
+
+function parseJSON(response) {
+    return response.json()
+}
+
+function displayScores(response) {
+    // An expired token or a backend error responds with an object, not an
+    // array, and sorting that would throw. Fall back to an empty list.
+    const scores = Array.isArray(response) ? response : []
+    clearLeaderboard(leaderboard)
+    topTenScores(scores).map(score => appendScore(score))
+}
+
+function topTenScores(scores) {
+    let sortedScores = scores.sort((a, b) => (b.score - a.score))
+    let topScores = sortedScores.slice(0, 10)
+    return topScores
+}
+
+function appendScore(score) {
+    let scoreItem = document.createElement('li')
+    scoreItem.innerHTML = `<h1>${score.user.username} ${score.score}</h1>`
+    leaderboard.appendChild(scoreItem)
+}
+
+function clearLeaderboard(leaderboard) {
+    while(leaderboard.firstChild) {
+        leaderboard.removeChild(leaderboard.firstChild);
+    }
+}

--- a/login.css
+++ b/login.css
@@ -1,0 +1,54 @@
+/* Styles for login.html only. Shared rules live in shared.css. */
+
+#nav-card-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+    background-image: url("assets/images/IMG_2859.JPG");
+    background-position: center;
+    background-repeat: no-repeat;
+    background-size: cover;
+    height: 100%;
+}
+
+#nav-card {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    margin-top: 150px;
+    height: 60%;
+    width: 50%;
+    border-style: solid;
+    border-color: greenyellow;
+    border-radius: 10%;
+    list-style: none;
+    box-shadow: 10px 5px 5px white;
+}
+
+.nav-bar-member {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+form {
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    width: 80%
+}
+
+h2 {
+    color: white;
+    font-family: 'Press Start 2P', cursive;
+}
+
+.form-title {
+    color: white;
+    font-family: 'Press Start 2P', cursive;
+}
+
+#sign-up-message {
+    color: white;
+    font-family: 'Press Start 2P', cursive;
+}

--- a/login.html
+++ b/login.html
@@ -3,7 +3,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <link rel="stylesheet" href="./game.css">
+    <link rel="stylesheet" href="./shared.css">
+    <link rel="stylesheet" href="./login.css">
     <link rel="shortcut icon" type="image/png" href="assets/icons/favicon.png"/>
     <script src="./login.js" defer></script>
     <title>Rave Mom</title>

--- a/session-guard.js
+++ b/session-guard.js
@@ -1,5 +1,6 @@
-// Runs before anything else on index.html: if there's no valid session,
-// bounce to the login page before Phaser or the game scripts ever load.
+// Runs before anything else on index.html and leaderboard.html: if there's no
+// valid session, bounce to the login page before Phaser, the game scripts, or
+// any page content ever load.
 // Wrapped in an IIFE so these locals never collide with the globals the
 // other scripts on this page share.
 (function() {

--- a/shared.css
+++ b/shared.css
@@ -1,0 +1,51 @@
+@import url('https://fonts.googleapis.com/css2?family=Press+Start+2P&display=swap');
+
+/* Panel geometry. The game canvas is 518x632 (see config in game.js), and the
+   dashboard and leaderboard are sized to match its *outer* box so every panel
+   across the site is the same size. Sizing off the outer box rather than the
+   bitmap means the canvas is never scaled, which would blur the pixel art. */
+:root {
+    --panel-border: 3px;
+    --panel-border-color: greenyellow;
+    --panel-width: 518px;
+    --panel-height: 632px;
+    --panel-outer-width: calc(var(--panel-width) + var(--panel-border) * 2);
+    --panel-outer-height: calc(var(--panel-height) + var(--panel-border) * 2);
+}
+
+* {
+    box-sizing: border-box;
+    background-color: black;
+}
+
+body, html {
+    height: 100%;
+    background-color: black;
+}
+
+.panel {
+    width: var(--panel-outer-width);
+    height: var(--panel-outer-height);
+    border: var(--panel-border) solid var(--panel-border-color);
+}
+
+.button-container {
+    display: flex;
+    flex-direction: row;
+    justify-content: center;
+}
+
+.button {
+    align-items: center;
+    background-color: white;
+    margin-top: 10px;
+    padding-top: 5px;
+    padding-bottom: 5px;
+    width: 60%;
+    font-size: 20px;
+    font-family: 'Press Start 2P', cursive;
+}
+
+.form-field {
+    background-color: white;
+}


### PR DESCRIPTION
## Summary

The game page was crowded. `#game-container` lays its children out in a flex **row**, and the leaderboard was a `display: none` sibling — so opening it dropped a third 30%-wide column inline beside the dashboard and canvas, squeezing the game rather than overlaying it.

This moves the leaderboard onto its own page, hides the dashboard buttons during play, squares up the panel sizing, and splits the single stylesheet per page.

Includes the spec and plan (`_specs/` and `_plans/`) alongside the implementation.

## What changed

**New `leaderboard.html`** — session-guarded, plain top-ten list, with the old Close button becoming "Return to Game". No welcome message or logout; the page's only control is the way back.

**Leaderboard removed from the game page.** The Leaderboard button navigates instead of expanding a panel in place, so the canvas is no longer competing for width.

**Buttons hidden during play.** Both Leaderboard and Log Out stay hidden through the start menu and active gameplay, appear once the knocked-out animation has looped, and hide again on restart. `GameScene` hands off to the page chrome via a `game-over` class on `<body>` — no shared globals, no load-order coupling. `visibility: hidden` rather than `display: none` keeps their space reserved so the dashboard doesn't shift when they appear.

**Consistent panel sizing.** The dashboard and leaderboard are sized to the canvas's *outer* box (bitmap + border) and declared once in `shared.css`. Sizing off the outer box rather than the bitmap means the canvas is never scaled, which would blur the pixel art.

**Stylesheet split.** `game.css` becomes `shared.css` + `login.css` + `game.css` (narrowed to game-page rules) + `leaderboard.css`. Each page loads exactly two.

**Duplication removed.** Leaderboard fetch/render previously lived in `dashboard.js` *and* again inside `gamescene.js`'s `create()`, with `gamescene.js` reaching across global scope for `dashboard.js`'s `leaderboard` and `scoresURL` bindings. With no leaderboard on the game page, that in-game copy is deleted rather than shared, and the global handoff is gone.

## One implementation note worth flagging

The button reveal hooks `animationrepeat`, **not** `animationcomplete`. The `playerloses` animation is created with `repeat: -1`, so it loops forever and never fires a completion event — `animationcomplete` would never have fired. Verified firing at **1347ms**, exactly one full loop (4 frames at frameRate 3), under Phaser 3.16.2.

## Verification

Walked end to end in the browser against the live backend:

- Session guard redirects on both `index.html` and `leaderboard.html`, no content flash
- Dashboard and canvas measure **524×638 each**, identical top and bottom
- Buttons hidden through start menu and play; revealed after the loop across 3 death cycles; hidden again on restart, with no layout shift
- Restart works with no `ReferenceError` — the highest-risk point, given the removed global handoff
- Leaderboard centered, same 524×638, top ten capped and sorted, list scrolls with title and button pinned
- Invalid token produces an empty list and **zero console output** — the `Array.isArray` guard earns its place
- Logout clears storage and returns to login; login page unchanged after the CSS split

**Testing gap:** verified with a synthetic session rather than creating an account, since signup would write to the production database. The populated leaderboard was exercised by driving `displayScores` with fixture data, not a real authenticated round trip — worth one manual login before merging.

## Explicitly deferred

- Responsive/resize behavior of the matched panel dimensions
- Keeping logout reachable mid-game (currently requires dying or reloading)
- Error and empty-state messaging — a failed fetch and a genuinely empty board currently look identical
- Showing the player's own score or rank alongside the top ten
- The broader HTML/CSS/JS directory reorganization — the remaining duplication is the API host, still hardcoded in three files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
