### PR TITLE
🧹 chore: stop deploying .git, repo docs and Aseprite sources

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,7 +46,21 @@ bases** and moving a file means checking which kind you're touching:
 
 ## Deployment
 
-Hosted on Firebase Hosting (`firebase.json`, `.firebaserc`, project `rave-mom`). The public root is `.` (the whole repo, minus dotfiles), so deploys are `firebase deploy` from the repo root.
+Hosted on Firebase Hosting (`firebase.json`, `.firebaserc`, project `rave-mom`). Deploys are `firebase deploy` from the repo root.
+
+The public root is `.` — the whole repo — so **hosting is opt-out, not opt-in**: every new file ships unless `firebase.json`'s `ignore` list excludes it. That list is the only thing standing between a working file and a public URL, and JSON can't hold comments, so it's documented here instead:
+
+| Pattern | Excludes |
+| --- | --- |
+| `**/.*` | dotfiles *themselves* (`.gitignore`, `.firebaserc`) |
+| `**/.*/**` | the *contents* of dot-directories (`.git/`, `.claude/`) |
+| `_specs/**`, `_plans/**` | specs and plans |
+| `CLAUDE.md`, `README.md` | repo docs — this file included |
+| `**/*.aseprite` | Aseprite sources; only the exported PNGs ship |
+
+The first two rows are the subtle part and both are needed. `**/.*` matches a path whose *final* segment starts with a dot, so it excludes `.git` but **not** `.git/config` — on its own it left the entire `.git` directory publicly fetchable, which is how the git history and an unpushed local branch ended up on the live site. `**/.*/**` is what covers files nested inside a dot-directory. Don't drop either one.
+
+A correct deploy reports **70 files**. If that number jumps, something that shouldn't be public probably is; the fastest check is the ignore list above.
 
 ## Architecture
 

--- a/firebase.json
+++ b/firebase.json
@@ -4,9 +4,13 @@
     "ignore": [
       "firebase.json",
       "**/.*",
+      "**/.*/**",
       "**/node_modules/**",
       "_specs/**",
-      "_plans/**"
+      "_plans/**",
+      "CLAUDE.md",
+      "README.md",
+      "**/*.aseprite"
     ]
   }
 }


### PR DESCRIPTION
Follow-up to #47 / #48. Started as the two cleanups discussed — exclude the repo docs and the Aseprite sources — but verifying the file count turned up something bigger.

## The thing worth reading

**`.git/` was being deployed and is publicly fetchable on the live site right now.**

I predicted the trimmed deploy would drop from 294 files to ~236, but my own glob check said only 132 files were shipping in the first place. That 162-file gap is almost exactly the 165 files in `.git/`. Confirmed against production:

```
200  /.git/config
200  /.git/HEAD
200  /.git/logs/HEAD
200  /.claude/settings.local.json
```

The cause is a subtle glob rule. `**/.*` matches a path whose **final segment** starts with a dot — so it excludes `.git` the directory entry, but not `.git/config`, `.git/HEAD`, or any other file *inside* it. The fix is `**/.*/**`, which matches contents nested inside a dot-directory. **Both patterns are needed**; neither subsumes the other.

### How bad

Limited, but not nothing:

- The GitHub repo is public, so the source and most history were already readable.
- `.claude/settings.local.json` contains only a `WebFetch` permission entry.
- The one genuinely non-public item was the **unpushed local branch `claude/feature/secure-plaintext-password-storage`**, whose objects were in `.git` at deploy time. The branch name alone advertises that the live app has a password-storage weakness.

No credentials or tokens were exposed. This is a "close the door" fix, not an incident.

## What changed

`firebase.json` gains four ignore entries:

| Added | Excludes |
| --- | --- |
| `**/.*/**` | contents of dot-directories (`.git/`, `.claude/`) |
| `CLAUDE.md`, `README.md` | repo docs, which documented the `localStorage` auth model at a public URL |
| `**/*.aseprite` | 56 Aseprite sources shipped alongside the PNGs actually loaded |

Plus a CLAUDE.md section documenting the `**/.*` vs `**/.*/**` distinction, since JSON can't carry a comment and this is exactly the kind of thing that gets "simplified" back out later.

## Verification

Ran the proposed ignore list against the real file list with `path.matchesGlob`:

```
files on disk (incl .git): 305
would deploy             :  70

dotdir files still kept  : 0  (want 0)
aseprite still kept      : 0  (want 0)
md still kept            : 0  (want 0)
```

The resulting 70-file manifest is exactly: 4 HTML pages, 4 stylesheets, 7 scripts, 51 PNGs, and the 4 images/favicons. Nothing the site needs is dropped — I diffed the manifest by hand against what the pages and the Phaser loader request.

`firebase.json` re-validated as JSON.

## Not fixed here

**This only affects future deploys.** The currently released version still serves `.git`. Merging this PR does not change the live site — a redeploy is required to actually pull those files down. Happy to run it once this merges.

Given the history was fetchable, rotating anything sensitive that ever lived in it would be the cautious move, though nothing in the current tree suggests there was any.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
