### PR TITLE
🔒 fix: stop storing the user's password in localStorage

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -67,7 +67,11 @@ A correct deploy reports **70 files**. If that number jumps, something that shou
 ### Frontend/backend split
 All game logic and UI live here; all persistence (users, auth tokens, scores) lives in the Rails API. The frontend talks to the backend over hardcoded URLs (e.g. `https://rave-mom-api.onrender.com/api/v1/users`, `/login`, `/scores`) — there's no env-based config, so backend URL changes require editing `js/login.js`, `js/leaderboard.js`, and `js/gamescene.js` directly (`js/gamescene.js` re-declares `scoresURL` inline in each of its two bomb handlers).
 
-Auth state is kept client-side in `localStorage` (`token`, `user_id`, `username`, `password`). Which page you're on determines how that state is treated: `js/login.js` clears all of `localStorage` on every load, so a fresh visit to the login page always starts clean; the scripts on `index.html` and `leaderboard.html` only ever *read* it, and clear it only on logout before navigating back to `login.html`. Requests to protected endpoints send `Authorization: bearer <token>`.
+Auth state is kept client-side in `localStorage` (`token`, `user_id`, `username`). Which page you're on determines how that state is treated: `js/login.js` clears all of `localStorage` on every load, so a fresh visit to the login page always starts clean; the scripts on `index.html` and `leaderboard.html` only ever *read* it, and clear it only on logout before navigating back to `login.html`. Requests to protected endpoints send `Authorization: bearer <token>`.
+
+**The password is never persisted.** It goes into the login request body and nowhere else — no `localStorage`, `sessionStorage`, or cookie. An earlier version stored it under a `password` key that nothing ever read; it was removed because a leaked password is unrevocable and widely reused, where a leaked token is neither. Don't reintroduce the write, and don't "secure" it by encrypting it client-side — any key the page can use, an attacker on that page can also recover.
+
+`js/clear-stored-password.js` exists only to clean up users who logged in before that change and would otherwise keep the stale key indefinitely (it's cleared on logout or on a login-page visit, but a user who stays logged in makes neither trip). It's deferred on `index.html` and `leaderboard.html`, removes exactly that one key, and swallows storage exceptions so private-browsing or disabled-site-data can't break the session. **It is temporary** — once the existing user population has cycled through, delete the file and both script tags.
 
 ### Page split & session flow
 - `login.html` — signup and login forms only. A successful login stores the session in `localStorage` and then does a real navigation (`window.location.href`) to `index.html`. Signup deliberately does *not* auto-navigate; it shows an inline message and requires a separate manual login.
@@ -85,6 +89,8 @@ The `.panel` custom properties in `css/shared.css` are derived from the canvas's
 All scripts live in `js/`. Global scripts, no modules/bundler — load order matters and all state hangs off the global `gameState` object defined in `js/game.js`:
 1. `js/session-guard.js` — the literal first tag in `<head>`, deliberately **not** deferred. Being a plain blocking script means it runs before the stylesheet, before the Phaser CDN request, and before any of `<body>` is parsed, so an invalid session redirects to `login.html` without ever loading or flashing the game.
 2. Phaser 3 (CDN)
+
+`js/clear-stored-password.js` sits right after the guard but is `defer`red, unlike it: nothing reads the key it deletes, so it has no ordering dependency and there's no reason to put a second blocking request on the critical path. If the guard redirects, the deferred script never runs — which is fine, because `js/login.js` clears all of storage on arrival anyway.
 3. `js/startmenu.js` — defines `StartMenu` Phaser scene (title screen, click-to-start)
 4. `js/gamescene.js` — defines `GameScene` Phaser scene (all core gameplay)
 5. `js/game.js` — creates `gameState` and the Phaser `Game` instance with `scene: [StartMenu, GameScene]`

--- a/_specs/secure-plaintext-password-storage.md
+++ b/_specs/secure-plaintext-password-storage.md
@@ -1,0 +1,52 @@
+# Spec for secure-plaintext-password-storage
+
+branch: claude/feature/secure-plaintext-password-storage
+
+## Summary
+
+On submitting the login form, `login.js` writes the user's raw password into `localStorage` under the key `password`, alongside `username`, `token`, and `user_id`. It sits there in plaintext, readable by any script running on the origin.
+
+The important finding from investigating this: **nothing ever reads that key.** There is no `getItem("password")` anywhere in the codebase. The value is written once at login and never consulted again — not by `session-guard.js`, not by `dashboard.js`, not by `gamescene.js`. Authentication against the backend uses the bearer `token` exclusively.
+
+So this is not a case of needing to protect a credential the app depends on. It is a stray write with no consumer, and the secure form of it is simply not to store it. Encrypting or obfuscating it client-side would be strictly worse: it would add machinery to guard a value nothing needs, and any client-side key is recoverable by the same attacker the scheme is meant to stop.
+
+The risk this closes is real but bounded. A token is revocable and scoped to this app; a password is neither, and users reuse passwords across sites. Any XSS on the game page, a malicious extension, or someone on a shared machine opening devtools currently walks away with the actual credential rather than a session artifact.
+
+There is also a residue problem. Users who logged in before this change already have the key sitting in their browser. Removing the write stops new ones but does not clean up existing ones. `login.js` calls `localStorage.clear()` on every load of the login page and `dashboard.js` clears on logout, so most users are cleaned up the next time they pass through either path — but a user who stays logged in and never revisits the login page keeps their stored password indefinitely. The fix needs to handle that population explicitly rather than relying on them happening to log out.
+
+## Functional Requirements
+
+- The login flow must not write the user's password to `localStorage`, `sessionStorage`, cookies, IndexedDB, or any other client-side persistence.
+- The password must still be sent to the login endpoint in the request body exactly as it is today. Only the local persistence is removed; the wire format and the backend contract are unchanged.
+- Any pre-existing `password` key must be actively removed from a returning user's storage, without requiring them to log out or visit the login page.
+- Removal of the stale key must not disturb `token`, `user_id`, or `username`, and must not log the user out or interrupt a game in progress.
+- The session must continue to work exactly as it does now: `session-guard.js` gates on `token` and `user_id`, the welcome message reads `username`, and authenticated requests send `Authorization: bearer <token>`.
+- The signup flow must remain free of any password persistence. It does not store one today and must not begin to.
+- No new dependency, build step, or bundler may be introduced. The project is plain static scripts loaded via tags and must stay that way.
+
+## Possible Edge Cases
+
+- A user is mid-game with a live session when the new code ships. The cleanup must run without resetting their score or disrupting the Phaser scene.
+- A user has `password` stored but no valid `token` — for example a login attempt that failed after the password write but before the token write. The guard should still redirect them to the login page, and the stale password should not survive that redirect.
+- `login.js` clears all of storage on load, so the login page itself needs no cleanup logic. Adding it there would be redundant; the cleanup has to live on the path a logged-in user actually takes.
+- Storage may be unavailable or throw — private browsing modes, disabled site data, quota errors. A failed cleanup must not throw an uncaught error that blocks the session guard or prevents the game from loading.
+- Multiple tabs open on the same origin. Cleanup in one tab must not put another tab into an inconsistent state.
+- A user with no `password` key at all, which is the steady state after this ships. The cleanup must be a no-op and must not create the key or error on its absence.
+
+## Acceptance Criteria
+
+- After a successful login, `localStorage` contains `token`, `user_id`, and `username`, and does not contain `password`.
+- After a failed login, `localStorage` does not contain `password`.
+- A browser seeded with a `password` key plus a valid session has that key removed on the next visit to the game page, while the session survives and the game loads normally.
+- A full grep of the source for `password` shows no writes to client-side storage.
+- The login request body still carries the password and the backend still authenticates successfully.
+- Session guard, welcome message, leaderboard, score submission, restart, and logout all behave as they do today.
+- The live site serves no page that writes a password to storage after deploy.
+
+## Open Questions
+
+- Where should the cleanup for returning users live? `session-guard.js` runs first on every game-page load and already touches storage, which makes it the natural host — but it is deliberately minimal and blocking, and its current job is purely to decide whether to redirect. Widening its responsibility to include storage hygiene may be the right call or may be worth keeping separate.
+- How long should the cleanup code stay in the codebase? It is only needed until the existing user population has cycled through. Worth deciding now whether it is permanent or gets a removal date, so it does not linger as unexplained code.
+- Should this change be paired with advising affected users to rotate their password? Anyone whose machine was already compromised has had the credential exposed, and removing it now does not undo that. This is a product/comms decision, not a code one.
+- The backend also accepts these credentials. Worth confirming separately whether `rave-mom-api` logs request bodies on the login route, since that would be the same exposure in a different place and outside this repo's control.
+- Should `username` persistence be revisited at the same time? It is not a credential and the welcome message depends on it, so it is likely fine, but it is the only other user-identifying value being stored.

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <script src="./js/session-guard.js"></script>
+    <script src="./js/clear-stored-password.js" defer></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="./css/shared.css">

--- a/js/clear-stored-password.js
+++ b/js/clear-stored-password.js
@@ -1,0 +1,20 @@
+// One-off cleanup for users who logged in before login.js stopped storing the
+// password. Removing the write only helps new logins; anyone already carrying a
+// `password` key keeps it until they next hit the login page or log out, which
+// a user who simply stays logged in may never do. This runs on the pages a
+// logged-in user actually lands on and clears the key out from under them.
+//
+// Deliberately narrow: it removes one key and touches nothing else, so the
+// session (token, user_id, username) and any game in progress are unaffected.
+//
+// Temporary by design — once the existing user population has cycled through,
+// this file and its two script tags can be deleted.
+(function() {
+    try {
+        localStorage.removeItem("password")
+    } catch (error) {
+        // Storage can throw in private browsing, with site data disabled, or on
+        // quota errors. This is opportunistic hygiene, not something worth
+        // breaking the page over, so swallow it and let the session continue.
+    }
+})()

--- a/js/login.js
+++ b/js/login.js
@@ -49,8 +49,10 @@ userLogin.addEventListener("submit", event => {
         password: formData.get("password")
     }
 
+    // Only the username is persisted. The password goes in the request body
+    // below and is never stored: nothing reads it back, and a stored password
+    // is a far worse thing to leak than a revocable token.
     localStorage.setItem("username", user.username)
-    localStorage.setItem("password", user.password)
 
     fetch(loginURL, {
         method: "POST",

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -2,6 +2,7 @@
 <html lang="en">
 <head>
     <script src="./js/session-guard.js"></script>
+    <script src="./js/clear-stored-password.js" defer></script>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="./css/shared.css">


### PR DESCRIPTION
Implements `_specs/secure-plaintext-password-storage.md` (the spec commit is included here — it was sitting on this branch unpushed).

## Answering the question directly: no, it was never needed

`js/login.js` wrote the raw password to `localStorage` on every login, beside `username`, `token` and `user_id`, where any script on the origin could read it.

**Nothing ever read it back.** There is no `getItem("password")` anywhere in the current tree, and none in any of the 2,112 historical blobs I scanned. It isn't reachable indirectly either — I checked for dynamic keys, `Object.keys(localStorage)`, `localStorage.key(i)` iteration and bulk `JSON.stringify(localStorage)`; every access in the codebase uses a literal string key. Authentication uses the bearer token exclusively.

It was a stray write with no consumer, so the secure form is simply not to store it. Encrypting it client-side would be strictly worse — machinery to guard a value nothing needs, protected by a key the same attacker could recover.

The password still goes in the login request body. Only the local persistence is gone; the wire format and backend contract are untouched.

Why it matters despite being unused: a token is revocable and scoped to this app, a password is neither and users reuse them. Any XSS, malicious extension, or shared machine with devtools open walked away with the real credential instead of a session artifact.

## The part that isn't one line

Removing the write only helps *new* logins. Anyone who already logged in is carrying the key right now.

`login.js` calls `localStorage.clear()` on load and `dashboard.js` clears on logout, so most users get cleaned up next time they pass through either path — but **a user who simply stays logged in makes neither trip and keeps their stored password indefinitely.**

So `js/clear-stored-password.js` handles that population. Per the discussion it's a separate script rather than logic added to `session-guard.js`, which stays narrowly about "redirect or don't."

- Deferred on `index.html` and `leaderboard.html` — the pages a logged-in user actually lands on. Not on `login.html`, which already clears everything.
- Removes exactly that one key and touches nothing else, so the session and any game in progress are unaffected.
- Wrapped in `try`/`catch`: storage throws in private browsing, with site data disabled, or on quota errors, and opportunistic hygiene must not break the page.
- **Temporary by design.** Once the user base has cycled through, delete the file and both script tags. Called out in the file header and in CLAUDE.md so it doesn't linger as unexplained code.

### Why deferred, when `session-guard.js` is deliberately blocking

Nothing reads the key, so this has no ordering dependency and there's no reason to put a second blocking request on the critical render path. If the guard redirects first, the deferred script never runs — which is fine, because `login.js` clears all of storage on arrival.

## Verification

Browser-tested against the spec's acceptance criteria, seeding `localStorage` to simulate each population:

| Scenario | Result |
|---|---|
| Stale password + valid session → `index.html` | key removed, `token`/`user_id`/`username` intact, no redirect, game loads |
| Stale password + valid session → `leaderboard.html` | key removed, session intact |
| Stale password + **no** token | guard redirects to `login.html`, storage ends up empty |
| Clean session, no password key | silent no-op, key not recreated |

No console errors in any case.

Static checks: no remaining writes of a password to `localStorage`, `sessionStorage`, or `document.cookie` anywhere; both request bodies still carry the password.

## Open questions from the spec, still open

These are yours to call, not code decisions:

- **Advising users to rotate.** Anyone already compromised had the credential exposed; removing it now doesn't undo that.
- **Whether `rave-mom-api` logs request bodies on the login route** — same exposure in a different place, outside this repo.
- **How long the cleanup script stays.** Worth picking a removal trigger now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
