### PR TITLE
🐛 fix: stop diagonal movement when two direction keys overlap

### DIFF
--- a/js/gamescene.js
+++ b/js/gamescene.js
@@ -605,25 +605,34 @@ class GameScene extends Phaser.Scene {
     
     update() {
         if(gameState.player.enable) {
+            // Clear both axes before dispatching, so exactly one direction is
+            // ever in effect. Each branch below sets a single axis and used to
+            // leave the other holding whatever velocity it was last given —
+            // so holding right and tapping down set velocity to (192, 192) and
+            // the player kept travelling diagonally at 271px/s, 41% faster
+            // than intended, until *every* key was released. Releasing down
+            // alone did not stop it.
+            //
+            // This also replaces the two branches that used to sit at the end
+            // of the chain. The first tried to suppress diagonals but was
+            // unreachable: any diagonal combination has a key that satisfies an
+            // earlier branch, so `down`/`up` always matched first. The second
+            // handled "no keys held", which the unconditional clear now covers.
+            gameState.player.setVelocityX(0);
+            gameState.player.setVelocityY(0);
+
             if(gameState.cursors.down.isDown && gameState.player.y <= 481) {
                 gameState.player.setVelocityY(192);
                 gameState.player.anims.play('walk-down', true);
             } else if(gameState.cursors.up.isDown && gameState.player.y >= 37) {
                 gameState.player.setVelocityY(-192);
                 gameState.player.anims.play('walk-up', true);
-            } else if(gameState.cursors.right.isDown && gameState.player.x <= 481) { 
+            } else if(gameState.cursors.right.isDown && gameState.player.x <= 481) {
                 gameState.player.setVelocityX(192);
                 gameState.player.anims.play('walk-right', true);
             } else if(gameState.cursors.left.isDown && gameState.player.x >= 37) {
                 gameState.player.setVelocityX(-192);
                 gameState.player.anims.play('walk-left', true);
-            } else if(((gameState.cursors.up.isDown) && (gameState.cursors.right.isDown)) || ((gameState.cursors.up.isDown) && (gameState.cursors.left.isDown)) ||
-            ((gameState.cursors.down.isDown) && (gameState.cursors.right.isDown)) || ((gameState.cursors.down.isDown) && (gameState.cursors.left.isDown))) {
-                gameState.player.setVelocityX(0);
-                gameState.player.setVelocityY(0); 
-            } else {
-                gameState.player.setVelocityX(0);
-                gameState.player.setVelocityY(0);   
             }
         }
     }


### PR DESCRIPTION
## The bug

Every branch of the movement chain in `GameScene.update()` sets a single axis, and none of them cleared the other one. Only the final "no keys held" branch cleared both. So a Y velocity picked up from a tap of `down` survived while `right` was still held:

| Input | Velocity |
| --- | --- |
| hold right | `(192, 0)` — correct |
| hold right, **+ down** | `(192, 192)` — diagonal |
| **release down**, keep right | `(192, 192)` — still diagonal |
| release everything | `(0, 0)` |

Three problems in one:

1. **Diagonal movement**, which the code was clearly written to prevent.
2. **Stuck velocity** — releasing `down` did not stop the vertical travel. It only cleared when *every* key came up. This is the worst of the three; the player keeps drifting off-axis while holding a single direction.
3. **A speed exploit** — 271px/s on the diagonal against an intended 192, 41% faster than the game is balanced for.

## The fix

Clear both axes before dispatching, so exactly one direction is effective per frame.

That also subsumes the two branches at the end of the chain, both removed here:

- **The diagonal-suppression branch was dead code.** It sat fifth in the `if`/`else` chain, but every diagonal combination contains a key that satisfies an earlier branch — `down.isDown` or `up.isDown` always matched first, so it was unreachable in normal play. (Strictly, it was reachable only when every held key failed its own bounds check, e.g. holding up+left while already outside the board's top-left corner.)
- **The "no keys held" branch** did exactly what the unconditional clear now does.

## Verification

Replayed the old and new branch chains frame by frame at 60fps:

```
                                   before          after
hold right                         (192, 0)        (192, 0)
hold right, +down                  (192, 192)      (0, 192)
hold right, +down, release down    (192, 192)      (192, 0)
release everything                 (0, 0)          (0, 0)

diagonal speed after fix: 192 px/s (intended 192)
single-key + idle behaviour identical to before: true
```

Key priority is unchanged — `down` > `up` > `right` > `left` by branch order — so holding down+right walks you down and ignores right, as it did before.

## What to test

- Single-direction movement feels exactly as it did.
- Holding two directions at once moves along one axis only, never diagonally.
- Releasing one of two held keys leaves the player moving cleanly along the remaining direction, with no drift on the other axis.
- Walk animations still match the direction of travel.
- Rave-girl collection and bomb deaths still work.

## Out of scope

This does **not** stop the player reaching the interiors of the board's maze blocks. That is still possible with axis-aligned moves alone — walk right along the top row to x = 111, then press down — and `getPlayerCol` still mis-reports those positions by up to 408px, checking the player against a tile on the opposite side of the board. Diagonal drift was the fast way in, not the only one.

That is tracked separately and is a larger decision: whether the board's 40 positions were ever meant to confine the player, or whether free roaming is the intended design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
