### PR TITLE
🕹️ fix: give the most recently pressed direction priority

### DIFF
--- a/js/gamescene.js
+++ b/js/gamescene.js
@@ -647,6 +647,22 @@ class GameScene extends Phaser.Scene {
             const held = directions.filter(direction => direction.key.isDown);
 
             if(held.length > 0) {
+                // A max-by: fold over everything held, carrying the larger
+                // timeDown forward, so this works for three or four keys at
+                // once and not just a pair.
+                //
+                // What makes the stamp usable is that Phaser writes it only on
+                // the down *transition* — `Key.onDown` sets timeDown inside an
+                // `if (!this.isDown)` guard. The OS fires repeated keydown
+                // events while a key is held, and those bump `repeats` but
+                // leave timeDown frozen at the moment of the press. So the
+                // stamps stay in press order for the whole hold and we don't
+                // have to track key order ourselves.
+                //
+                // `>=` only matters for two keys stamped in the same event
+                // batch; it breaks the tie toward the end of `directions`.
+                // Which one wins is arbitrary, but it has to be *stable*, or a
+                // tie would flip direction from frame to frame.
                 const active = held.reduce((latest, direction) =>
                     direction.key.timeDown >= latest.key.timeDown ? direction : latest);
 

--- a/js/gamescene.js
+++ b/js/gamescene.js
@@ -621,18 +621,51 @@ class GameScene extends Phaser.Scene {
             gameState.player.setVelocityX(0);
             gameState.player.setVelocityY(0);
 
-            if(gameState.cursors.down.isDown && gameState.player.y <= 481) {
-                gameState.player.setVelocityY(192);
-                gameState.player.anims.play('walk-down', true);
-            } else if(gameState.cursors.up.isDown && gameState.player.y >= 37) {
-                gameState.player.setVelocityY(-192);
-                gameState.player.anims.play('walk-up', true);
-            } else if(gameState.cursors.right.isDown && gameState.player.x <= 481) {
-                gameState.player.setVelocityX(192);
-                gameState.player.anims.play('walk-right', true);
-            } else if(gameState.cursors.left.isDown && gameState.player.x >= 37) {
-                gameState.player.setVelocityX(-192);
-                gameState.player.anims.play('walk-left', true);
+            // The bounds used to gate the *input* (`up.isDown && y >= 37`) and
+            // were tested before the move, so the player took one more 3.2px
+            // step, landed outside the boundary, and the test then failed for
+            // good. Clamping the position instead keeps the player on the board
+            // and keeps a direction from disabling itself by overshooting.
+            gameState.player.x = Phaser.Math.Clamp(gameState.player.x, 37, 481);
+            gameState.player.y = Phaser.Math.Clamp(gameState.player.y, 37, 481);
+
+            // Most recently pressed key wins. Phaser stamps every Key with
+            // timeDown, so the direction in effect is simply the held key with
+            // the latest stamp — no keydown bookkeeping of our own.
+            //
+            // An if/else chain can't express this: it hardcodes one fixed
+            // priority order, which made the controls asymmetric. Under the old
+            // `down > up > right > left`, pressing up while holding right took
+            // over, but pressing right while holding up did nothing at all.
+            const directions = [
+                { key: gameState.cursors.up,    vx: 0,    vy: -192, anim: 'walk-up' },
+                { key: gameState.cursors.down,  vx: 0,    vy: 192,  anim: 'walk-down' },
+                { key: gameState.cursors.left,  vx: -192, vy: 0,    anim: 'walk-left' },
+                { key: gameState.cursors.right, vx: 192,  vy: 0,    anim: 'walk-right' }
+            ];
+
+            const held = directions.filter(direction => direction.key.isDown);
+
+            if(held.length > 0) {
+                const active = held.reduce((latest, direction) =>
+                    direction.key.timeDown >= latest.key.timeDown ? direction : latest);
+
+                // At an edge the chosen direction stays chosen and simply
+                // produces no movement, rather than falling through to another
+                // one. Falling through is what used to send you sideways along
+                // the top row while you were holding up.
+                const blocked =
+                    (active.vy < 0 && gameState.player.y <= 37) ||
+                    (active.vy > 0 && gameState.player.y >= 481) ||
+                    (active.vx < 0 && gameState.player.x <= 37) ||
+                    (active.vx > 0 && gameState.player.x >= 481);
+
+                if(!blocked) {
+                    gameState.player.setVelocityX(active.vx);
+                    gameState.player.setVelocityY(active.vy);
+                }
+
+                gameState.player.anims.play(active.anim, true);
             }
         }
     }


### PR DESCRIPTION
Follow-up to #52.

## The asymmetry

`up` was already prioritised over the horizontals — the chain was `down > up > right > left`, so both verticals beat both horizontals. But a fixed order makes the controls asymmetric in a way that's easy to feel and hard to name:

| Input | Old result |
| --- | --- |
| holding **right**, press **up** | moves up — the new key takes over |
| holding **up**, press **right** | still moves up — the new key is ignored |

Selecting the held key with the latest `timeDown` makes those mirror each other. Phaser stamps every `Key` with `timeDown` already, so this needs no keydown bookkeeping of our own — the `if`/`else` chain simply can't express "most recent wins", which is why it's now a list.

## Two edge bugs, one cause

The bounds gated the *input* (`up.isDown && player.y >= 37`) and were tested before the move:

1. **The player escaped the board.** One more 3.2px step landed them outside the boundary, and the test then failed for good — the direction disabled itself permanently.
2. **A blocked direction fell through to a lower-priority one.** Holding up on the top row and adding right sent the player sideways. The player spawns at **y = 37**, which *is* the top row, so this was reachable in the first second of play.

Clamping the position instead fixes both. A chosen direction now stays chosen at an edge and produces no movement.

## Verification

Replayed the new `update()` frame by frame at 60fps:

```
hold right, then press up       -> vel=(0,-192) anim=up
hold up, then press right       -> vel=(192,0)  anim=right     symmetric
hold right, up, release up      -> vel=(192,0)  falls back to the held key
hold up, right, release right   -> vel=(0,-192) falls back to the held key

right + down held               -> vel=(0,192)  no diagonal
release down (right still held) -> vel=(192,0)  no stuck velocity

hold up on top row (259,37)     -> pos=(259.0, 37.0)  pinned exactly
hold right then up, top row     -> pos=(307.0, 37.0)  pinned, no sideways drift
hold up then right, top row     -> pos=(355.0, 37.0)  right is newer, so it moves
hold down on bottom row         -> pos=(259.0, 481.0) pinned exactly
spawn corner, up then right     -> pos=(133.0, 37.0)  moves right
```

Bounds stress test — 200k frames, up to three keys held at once, direction changes every 300 frames so the player buries itself in every wall:

```
                x range              y range          out-of-bounds frames
physics-first   37.00 .. 481.00      37.00 .. 481.00           0
update-first    36.20 .. 483.00      35.00 .. 481.80         344
```

`physics-first` is Phaser's real ordering — the Arcade plugin integrates velocity on the scene's `UPDATE` event, which fires before `scene.update()` — so the clamp lands immediately after the move and before rendering. The pessimistic ordering is shown for contrast: even there the overshoot is ≤2px and self-heals on the next frame, and a direction never permanently disables itself either way.

## What to test

- Hold **up**, then press **right** — should switch to right. Then release right — should go back to up.
- Same in reverse: hold right, press up, release up.
- On the **spawn row**, hold up and add right. Old behaviour drifted you sideways; now up stays in control until you release it.
- Walk into each of the four walls and confirm the player stops flush against the edge rather than easing slightly past it.
- Walk animations match the direction actually being travelled.
- Rave-girl collection and bomb deaths still work.

## Not covered

Verified by simulation of the branch logic, not by playing. Animations and collisions want a human at the keyboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
