### PR TITLE
🔍 debug: add arrow-key input diagnostics

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The public root is `.` — the whole repo — so **hosting is opt-out, not opt-i
 
 The first two rows are the subtle part and both are needed. `**/.*` matches a path whose *final* segment starts with a dot, so it excludes `.git` but **not** `.git/config` — on its own it left the entire `.git` directory publicly fetchable, which is how the git history and an unpushed local branch ended up on the live site. `**/.*/**` is what covers files nested inside a dot-directory. Don't drop either one.
 
-A correct deploy reports **71 files**. If that number jumps, something that shouldn't be public probably is; the fastest check is the ignore list above. Update this number whenever a file is deliberately added or removed — it was stale at 70 for a while after `js/clear-stored-password.js` landed, which makes the tripwire useless in both directions.
+A correct deploy reports **72 files**. If that number jumps, something that shouldn't be public probably is; the fastest check is the ignore list above. Update this number whenever a file is deliberately added or removed — it was stale at 70 for a while after `js/clear-stored-password.js` landed, which makes the tripwire useless in both directions.
 
 ### Use a current CLI — an old one silently publishes an empty site
 
@@ -108,6 +108,7 @@ All scripts live in `js/`. Global scripts, no modules/bundler — load order mat
 4. `js/gamescene.js` — defines `GameScene` Phaser scene (all core gameplay)
 5. `js/game.js` — creates `gameState` and the Phaser `Game` instance with `scene: [StartMenu, GameScene]`
 6. `js/dashboard.js` — welcome message, logout, and navigation to the leaderboard. Declared in `<head>` but `defer`red, so it runs *after* the plain body scripts above.
+7. `js/input-debug.js` — arrow-key diagnostics. Also `defer`red in `<head>`, and order-independent: it only defines `window.inputDebug` and reads `gameState` lazily, when one of its functions is called.
 
 Note that steps 2–5 are plain body `<script>` tags: they execute synchronously during parsing, and therefore before any deferred `<head>` script.
 

--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
     <link rel="stylesheet" href="./css/game.css">
     <link rel="shortcut icon" type="image/png" href="assets/icons/favicon.png"/>
     <script src="./js/dashboard.js" defer></script>
+    <script src="./js/input-debug.js" defer></script>
     <title>Rave Mom</title>
 </head>
 <body>

--- a/js/input-debug.js
+++ b/js/input-debug.js
@@ -1,0 +1,113 @@
+// Diagnostics for the arrow-key controls. Inert until you switch it on —
+// nothing here listens or logs unless you call one of these from the DevTools
+// console (or load the page with ?debug=input, which starts both):
+//
+//   inputDebug.dom()    every arrow keydown/keyup the browser delivers
+//   inputDebug.game()   what Phaser's Key objects and the player sprite did
+//   inputDebug.off()    stop both
+//
+// The two exist separately because they answer different questions, and the
+// answer decides whether there's a bug to fix at all. `dom()` listens on
+// window and sees the raw events. If you hold two arrows, press a third, and
+// `dom()` never logs it, the keyboard dropped that press before any of our
+// code ran — arrow clusters on laptop and membrane keyboards frequently can't
+// report three at once — and nothing in gamescene.js can recover a keypress
+// the browser was never told about. If `dom()` logs the third key but `game()`
+// shows it never took over, then it's ours.
+//
+// `game()` reports the sprite's *measured* velocity rather than recomputing
+// which direction ought to have won. Re-deriving that rule here would leave a
+// second copy of it free to drift out of step with update()'s — and a drifted
+// copy would happily agree with itself while the game did something else.
+(function() {
+    const isArrow = key => typeof key === "string" && key.indexOf("Arrow") === 0;
+    const shortName = key => key.slice(5);
+
+    let domListeners = null;
+    let gameFrame = null;
+
+    function startDom() {
+        if(domListeners) return;
+
+        const held = new Set();
+        const list = () => [...held].map(shortName).join("+") || "(none)";
+
+        // e.repeat filters the OS's auto-repeat keydowns. They aren't new
+        // presses, and Phaser ignores them for timeDown too, so logging them
+        // would bury the transitions that actually matter under a stream of
+        // duplicates.
+        const onDown = event => {
+            if(!isArrow(event.key) || event.repeat) return;
+            held.add(event.key);
+            console.log("[dom] DOWN", shortName(event.key).padEnd(6), "held:", list());
+        };
+
+        const onUp = event => {
+            if(!isArrow(event.key)) return;
+            held.delete(event.key);
+            console.log("[dom] UP  ", shortName(event.key).padEnd(6), "held:", list());
+        };
+
+        window.addEventListener("keydown", onDown);
+        window.addEventListener("keyup", onUp);
+        domListeners = { onDown, onUp };
+
+        console.log("[dom] on — logs raw browser key events. inputDebug.off() to stop.");
+    }
+
+    function startGame() {
+        if(gameFrame !== null) return;
+
+        // Logs on change rather than on a timer: holding a key steady produces
+        // one line, so what's left in the console is the transitions.
+        let previous = null;
+
+        const tick = () => {
+            gameFrame = requestAnimationFrame(tick);
+
+            // create() hasn't necessarily run — the game sits on the start menu
+            // until you click, and GameScene builds cursors and the player only
+            // after its preload finishes.
+            const cursors = window.gameState && gameState.cursors;
+            const player = window.gameState && gameState.player;
+            if(!cursors || !player || !player.body) return;
+
+            const names = ["up", "down", "left", "right"];
+            const held = names.filter(name => cursors[name].isDown);
+            const stamps = held.map(name => `${name}@${cursors[name].timeDown | 0}`).join(" ");
+            const velocity = `(${Math.round(player.body.velocity.x)},${Math.round(player.body.velocity.y)})`;
+            const anim = player.anims.currentAnim ? player.anims.currentAnim.key : "(none)";
+
+            const line = `${(held.join("+") || "(none)").padEnd(20)} ${stamps.padEnd(48)} vel=${velocity.padEnd(12)} anim=${anim}`;
+            if(line === previous) return;
+            previous = line;
+
+            console.log("[game]", line);
+        };
+
+        tick();
+        console.log("[game] on — logs held keys, timeDown stamps, and measured velocity on change.");
+    }
+
+    function off() {
+        if(domListeners) {
+            window.removeEventListener("keydown", domListeners.onDown);
+            window.removeEventListener("keyup", domListeners.onUp);
+            domListeners = null;
+        }
+
+        if(gameFrame !== null) {
+            cancelAnimationFrame(gameFrame);
+            gameFrame = null;
+        }
+
+        console.log("[inputDebug] off");
+    }
+
+    window.inputDebug = { dom: startDom, game: startGame, off: off };
+
+    if(new URLSearchParams(window.location.search).get("debug") === "input") {
+        startDom();
+        startGame();
+    }
+})();


### PR DESCRIPTION
Adds `js/input-debug.js`, a diagnostic for the arrow-key controls. Split out of #53 so that PR stays a single behavioural change.

## Why

When the controls feel wrong there are two very different possible causes, and you can't tell them apart by playing:

1. The browser never received the keypress.
2. The browser received it and the game did the wrong thing.

Arrow clusters on laptop and membrane keyboards frequently can't report three simultaneous presses — the keyboard controller drops the third. No change to `gamescene.js` can recover a `keydown` that was never delivered, so distinguishing (1) from (2) has to come first.

This came up immediately: while testing #53, holding up + down and then pressing right appeared to leave the player moving vertically. `dom()` showed no `DOWN Right` event at all, which ruled out the game logic in one step.

## What it does

```js
inputDebug.dom()    // raw browser key events
inputDebug.game()   // Phaser Key state + measured sprite velocity
inputDebug.off()    // stop both
```

Or load `index.html?debug=input` to start both automatically.

`dom()` logs each arrow keydown/keyup with the running held-set, filtering `event.repeat` so OS auto-repeat doesn't bury the real transitions.

`game()` logs on *change* rather than on a timer, so holding a key steady produces one line:

```
[game] up+right    up@12043 right@12981    vel=(192,0)    anim=walk-right
```

Held keys, their `timeDown` stamps, the sprite's measured velocity, and the playing animation.

## Two deliberate choices

**`game()` reports measured velocity rather than recomputing which direction should have won.** Re-deriving that rule here would leave a second copy of `update()`'s selection logic free to drift out of step with the real one — and a drifted copy would agree with itself while the game did something else entirely.

**Inert by default.** The file defines `window.inputDebug` and nothing more: no listeners, no frame callback, no logging until a function is called. Deferred and order-independent, since it reads `gameState` lazily at call time — which it has to anyway, because `cursors` and `player` don't exist until `GameScene`'s preload finishes.

## Notes

- `CLAUDE.md`: deploy tripwire 71 → 72 files, plus the load-order entry.
- The file ships to production. It's ~100 lines and does nothing unless invoked, and being able to diagnose input on a real device is worth more than the bytes.

## Testing

- `?debug=input` starts both loggers; `inputDebug.off()` stops them.
- Without the query param and without calling anything, the console stays silent and no listeners are registered.
- Calling `dom()` or `game()` twice is a no-op rather than a double subscription.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
