### PR TITLE
🎯 fix: report the nearest grid cell instead of guessing from bands

### DIFF
--- a/js/gamescene.js
+++ b/js/gamescene.js
@@ -59,8 +59,13 @@ class GameScene extends Phaser.Scene {
             ],
             row7: [
                 [37, 481], [111, 481], [185, 481], [259, 481], [333, 481], [407, 481], [481, 481]
-            ]  
+            ]
         }
+
+        // The same 40 cells as one flat list, for the nearest-cell search in
+        // getPlayerGridPosition. Derived rather than typed out, so it can't
+        // drift from the rows above the way a hand-copied list would.
+        gameState.gridCells = Object.values(gameState.playerGridPositions).flat()
 
         gameState.explosionPositions = {
             bomb1: [
@@ -535,58 +540,38 @@ class GameScene extends Phaser.Scene {
             return contains;
         }
 
+        // The player is almost never standing exactly on a grid cell. Movement
+        // is continuous at 192px/s, so at 60fps the sprite advances 3.2px per
+        // frame and a bomb's animation finishes wherever it finishes. Any
+        // answer to "which cell is the player on?" has to cope with being
+        // between cells, because that is the normal case rather than the edge
+        // one.
+        //
+        // Taking the nearest of the 40 legal cells always names a cell the
+        // player is genuinely near: at most 37px away in a corridor, at most
+        // 74px in a block interior, where all four neighbours are equidistant.
+        //
+        // The pair of band tests this replaces had no such bound. Even rows
+        // hold only 4 legal cells, so getPlayerCol tested four narrow x bands
+        // and funnelled everything outside them into `return 3` — the widest
+        // gap being x in (74, 148]. A player at (75, 76) came back as
+        // (481, 111), 444px from the cell it should have named, on the
+        // opposite side of the board. Averaged over the whole board the old
+        // answer was 57px wrong.
+        //
+        // This result feeds the bomb collision check, so a wrong cell means
+        // being killed standing somewhere safe, or walking through a blast
+        // untouched.
+        //
+        // Squared distances order identically to real ones and skip 40 square
+        // roots. Exact ties keep the first cell found, so a player poised
+        // midway between two cells reports one of them steadily instead of
+        // alternating frame to frame.
         function getPlayerGridPosition(player) {
-            let playerRow = getPlayerRow(player)
-            let playerCol = getPlayerCol(player)
-            return gameState.playerGridPositions[playerRow][playerCol]
-        }
-        
-        function getPlayerRow(player) {
-            if(player.y <= 74) {
-                return 'row1';
-            } else if(player.y > 74 && player.y <= 148) {
-                return 'row2';
-            } else if(player.y > 148 && player.y <= 222) {
-                return 'row3';
-            } else if(player.y > 222 && player.y <= 296) {
-                return 'row4';
-            } else if(player.y > 296 && player.y <= 370) {
-                return 'row5';
-            } else if(player.y > 370 && player.y <= 444) {
-                return 'row6';
-            } else {
-                return 'row7';
-            }
-        }
-
-        function getPlayerCol(player) {
-            if(getPlayerRow(player) === 'row1' || getPlayerRow(player) === 'row3' || getPlayerRow(player) === 'row5' || getPlayerRow(player) === 'row7') {
-                if(player.x <= 74) {
-                    return 0;
-                } else if(player.x > 74 && player.x <= 148) {
-                    return 1;
-                } else if(player.x > 148 && player.x <= 222) {
-                    return 2;
-                } else if(player.x > 222 && player.x <= 296) {
-                    return 3;
-                } else if(player.x > 296 && player.x <= 370) {
-                    return 4;
-                } else if(player.x > 370 && player.x <= 444) {
-                    return 5;
-                } else {
-                    return 6;
-                }
-            } else {
-                if(player.x <= 74) {
-                    return 0;
-                } else if(player.x > 148 && player.x <= 222) {
-                    return 1;
-                } else if(player.x > 296 && player.x <= 370) {
-                    return 2;
-                } else {
-                    return 3;
-                }
-            }
+            return gameState.gridCells.reduce((nearest, cell) => {
+                const distance = (cell[0] - player.x) ** 2 + (cell[1] - player.y) ** 2;
+                return distance < nearest.distance ? { cell: cell, distance: distance } : nearest;
+            }, { cell: gameState.gridCells[0], distance: Infinity }).cell;
         }
         
         // The Leaderboard and Log Out buttons live in the dashboard markup, but


### PR DESCRIPTION
Replaces `getPlayerGridPosition`'s band tests with a nearest-cell search. Net **-15 lines**; `getPlayerRow` and `getPlayerCol` are deleted along with it.

## The bug

`getPlayerGridPosition` answers "which grid cell is the player on?", and its only consumer is the bomb collision check — so a wrong answer means being killed while standing somewhere safe, or walking through a blast untouched.

It worked by slicing x and y into bands, which is only correct if the player is sitting exactly on a legal coordinate. They almost never are: movement is continuous at 192px/s, so the sprite advances 3.2px per frame and a bomb's animation completes wherever it completes.

`getPlayerCol` was the broken half. Even rows hold only 4 legal cells (x ∈ {37,185,333,481}), so it tested four narrow bands and sent everything else to `return 3`:

```js
if(player.x <= 74) return 0;
else if(player.x > 148 && player.x <= 222) return 1;
else if(player.x > 296 && player.x <= 370) return 2;
else return 3;                                  // ← x ∈ (74,148] lands here, and so does (222,296] and (370,481]
```

The gaps are wider than the bands. A player at **(75, 76)** was reported at **(481, 111)** — 444px from the cell it should have named, on the far side of the board.

## The fix

```js
gameState.gridCells = Object.values(gameState.playerGridPositions).flat()
```

```js
function getPlayerGridPosition(player) {
    return gameState.gridCells.reduce((nearest, cell) => {
        const distance = (cell[0] - player.x) ** 2 + (cell[1] - player.y) ** 2;
        return distance < nearest.distance ? { cell: cell, distance: distance } : nearest;
    }, { cell: gameState.gridCells[0], distance: Infinity }).cell;
}
```

Squared distances order identically to real ones and skip 40 square roots. Exact ties keep the first cell found, so a player poised midway between two cells reports one of them steadily rather than alternating frame to frame.

The flat list is **derived** from `playerGridPositions`, not typed out again — the repo already has a documented problem with parallel hand-authored coordinate structures, and this adds no new one.

## Verification

Swept every integer position on the board (198,025 of them), comparing both implementations against the true nearest cell:

```
exact-cell inputs mapped to themselves:  old 40/40   new 40/40
worst error vs true nearest cell:        old 444.0px   new 0.0px
mean error:                              old  57.1px   new 0.0px
worst old case:                          (75,76) -> [481,111]
new results outside the 40 legal cells:  0

max snap distance, on a corridor line:   37.0px  at (37,74)
max snap distance, off the maze:         74.0px  at (111,111)
```

The new result is exact by construction, so the interesting numbers are the bounds: **≤37px** when the player is on one of the maze's 8 corridor lines, **≤74px** anywhere else — the 74px case being block interiors, where all four neighbours are equidistant and no answer is better than any other.

## Scope

This makes the *reporting* honest. It doesn't stop the player from standing between cells — free movement still allows that, including inside block interiors. Being 37px off is a fairer answer than being 444px off, but it's still an approximation; only grid-locked movement would make the question exact. That's a design change, not a bug fix, and isn't attempted here.

## Unrelated bug spotted nearby, not fixed

`setInitialRaveGirlPosition` compares a number against an array:

```js
if(ravegirlstartX === getPlayerGridPosition(gameState.player) && ...)
```

`getPlayerGridPosition` returns `[x, y]`, so this is always `false` and the re-roll never happens — a rave girl can spawn on the player's start position. Pre-existing and untouched by this PR (it was equally broken before), but worth its own change.

## Testing

- No behavioural change when the player is exactly on a cell — all 40 map to themselves under both implementations.
- Play a round and walk into a blast mid-corridor; the collision now resolves against the cell you're actually nearest.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
