### PR TITLE
🔍 fix: make inputDebug.game() actually log something

### DIFF
--- a/js/input-debug.js
+++ b/js/input-debug.js
@@ -68,8 +68,18 @@
             // create() hasn't necessarily run — the game sits on the start menu
             // until you click, and GameScene builds cursors and the player only
             // after its preload finishes.
-            const cursors = window.gameState && gameState.cursors;
-            const player = window.gameState && gameState.player;
+            //
+            // The guard has to be typeof, not `window.gameState`. js/game.js
+            // declares gameState as a top-level const in a classic script, so
+            // it lands in the global lexical environment rather than on the
+            // global object: every later script can see the name, but
+            // window.gameState is undefined. Testing that property meant this
+            // logger bailed on every frame and printed nothing from the day it
+            // landed, while still reporting itself as on.
+            if(typeof gameState === "undefined") return;
+
+            const cursors = gameState.cursors;
+            const player = gameState.player;
             if(!cursors || !player || !player.body) return;
 
             const names = ["up", "down", "left", "right"];


### PR DESCRIPTION
`inputDebug.game()` has never logged a line. Shipped broken in #54 and currently live.

## The bug

```js
const cursors = window.gameState && gameState.cursors;
const player = window.gameState && gameState.player;
if(!cursors || !player || !player.body) return;
```

`js/game.js` declares `gameState` as a **top-level `const` in a classic script**. That binding goes into the *global lexical environment*, not onto the global object — every later script can see the name, but `window.gameState` is `undefined`.

So the guard was false on every frame and the callback returned immediately, every time.

```
gameState visible lexically : true
window.gameState truthy     : false   <-- what input-debug.js tested
```

## Why nobody noticed

It fails quietly in the worst possible way. Calling `inputDebug.game()` still prints its "on" banner and still schedules a `requestAnimationFrame` loop, so it looks like it's running. And it's a tool whose normal behaviour is to stay silent until something changes — an empty log reads as "nothing happened yet", not "broken".

`dom()` was never affected: it reads nothing off `gameState`, which is why it gave a usable answer about the keyboard rollover.

## The fix

```js
if(typeof gameState === "undefined") return;

const cursors = gameState.cursors;
const player = gameState.player;
if(!cursors || !player || !player.body) return;
```

`typeof` is the check that works for a lexical binding. The `undefined` case is still real and still needs guarding — the game sits on the start menu until you click, and `GameScene` builds `cursors` and `player` only after its preload finishes.

## Verification

Ran `js/game.js`'s declaration and this file as **separate scripts in one shared context**, with `window` aliased to the global object as a browser has it, and the source unmodified:

```
master    [game] lines: 1   -> [game] on — logs held keys, timeDown stamps, and measured velocity...
fixed     [game] lines: 2   -> [game] up                   up@10   vel=(0,-192)  anim=walk-up
```

`master` emits only the banner and never a state line. The fix emits state.

(My first attempt at this harness rewrote `window.` out of the source and "proved" both versions worked — worth noting, since it's the obvious way to write the test and it silently tests nothing.)

## Testing

Load the game, start a round, run `inputDebug.game()`, press an arrow key. You should now see lines like:

```
[game] up+right    up@12043 right@12981    vel=(192,0)    anim=walk-right
```

Previously: nothing, forever.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
