### PR TITLE
🔌 chore: move the backend endpoints into js/api.js

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -60,7 +60,7 @@ The public root is `.` — the whole repo — so **hosting is opt-out, not opt-i
 
 The first two rows are the subtle part and both are needed. `**/.*` matches a path whose *final* segment starts with a dot, so it excludes `.git` but **not** `.git/config` — on its own it left the entire `.git` directory publicly fetchable, which is how the git history and an unpushed local branch ended up on the live site. `**/.*/**` is what covers files nested inside a dot-directory. Don't drop either one.
 
-A correct deploy reports **74 files**. If that number jumps, something that shouldn't be public probably is; the fastest check is the ignore list above. Update this number whenever a file is deliberately added or removed — it was stale at 70 for a while after `js/clear-stored-password.js` landed, which makes the tripwire useless in both directions.
+A correct deploy reports **75 files**. If that number jumps, something that shouldn't be public probably is; the fastest check is the ignore list above. Update this number whenever a file is deliberately added or removed — it was stale at 70 for a while after `js/clear-stored-password.js` landed, which makes the tripwire useless in both directions.
 
 ### Use a current CLI — an old one silently publishes an empty site
 
@@ -78,7 +78,11 @@ It exits successfully with a green tick. The only signal is `found 0 files`, and
 ## Architecture
 
 ### Frontend/backend split
-All game logic and UI live here; all persistence (users, auth tokens, scores) lives in the Rails API. The frontend talks to the backend over hardcoded URLs (e.g. `https://rave-mom-api.onrender.com/api/v1/users`, `/login`, `/scores`) — there's no env-based config, so backend URL changes require editing `js/login.js`, `js/leaderboard.js`, and `js/gamescene.js` directly (`js/gamescene.js` re-declares `scoresURL` inline in each of its two bomb handlers).
+All game logic and UI live here; all persistence (users, auth tokens, scores) lives in the Rails API.
+
+Every backend URL lives in `js/api.js`, which defines `API_BASE` and an `API` object with `users`, `login`, and `scores`. The paths are built from `API_BASE`, so **the host appears exactly once in the codebase** — pointing at a different backend is a one-line change. It is still hardcoded rather than configured: there is no build step to substitute an environment value, and the browser needs a URL it can reach.
+
+`js/api.js` loads on all three pages and must precede anything that fetches. On `index.html` that means a plain body script before `js/gamescene.js`; on `login.html` and `leaderboard.html` a deferred tag before their deferred page script, which works because deferred scripts run in document order and keeps the critical path free of another blocking request.
 
 Auth state is kept client-side in `localStorage` (`token`, `user_id`, `username`). Which page you're on determines how that state is treated: `js/login.js` clears all of `localStorage` on every load, so a fresh visit to the login page always starts clean; the scripts on `index.html` and `leaderboard.html` only ever *read* it, and clear it only on logout before navigating back to `login.html`. Requests to protected endpoints send `Authorization: bearer <token>`.
 
@@ -104,17 +108,18 @@ All scripts live in `js/`. Global scripts, no modules/bundler — load order mat
 2. Phaser 3 (CDN)
 
 `js/clear-stored-password.js` sits right after the guard but is `defer`red, unlike it: nothing reads the key it deletes, so it has no ordering dependency and there's no reason to put a second blocking request on the critical path. If the guard redirects, the deferred script never runs — which is fine, because `js/login.js` clears all of storage on arrival anyway.
-3. `js/board-data.js` — defines the `BOARD` global: every fixed coordinate the maze is made of. Must precede `js/gamescene.js`, which reads it.
-4. `js/touch-input.js` — defines the `TOUCH` global: hold-to-move touch controls. Must precede `js/gamescene.js`, which reads it, and follow `js/board-data.js`, whose `BOARD` it derives the play field from.
-5. `js/startmenu.js` — defines `StartMenu` Phaser scene (title screen, click-to-start)
-6. `js/gamescene.js` — defines `GameScene` Phaser scene (all core gameplay)
-7. `js/game.js` — creates `gameState` and the Phaser `Game` instance with `scene: [StartMenu, GameScene]`
-8. `js/dashboard.js` — welcome message, logout, and navigation to the leaderboard. Declared in `<head>` but `defer`red, so it runs *after* the plain body scripts above.
-9. `js/input-debug.js` — arrow-key diagnostics. Also `defer`red in `<head>`, and order-independent: it only defines `window.inputDebug` and reads `gameState` lazily, when one of its functions is called.
+3. `js/api.js` — defines `API_BASE` and `API`: every backend URL. Must precede `js/gamescene.js`, which fetches with it.
+4. `js/board-data.js` — defines the `BOARD` global: every fixed coordinate the maze is made of. Must precede `js/gamescene.js`, which reads it.
+5. `js/touch-input.js` — defines the `TOUCH` global: hold-to-move touch controls. Must precede `js/gamescene.js`, which reads it, and follow `js/board-data.js`, whose `BOARD` it derives the play field from.
+6. `js/startmenu.js` — defines `StartMenu` Phaser scene (title screen, click-to-start)
+7. `js/gamescene.js` — defines `GameScene` Phaser scene (all core gameplay)
+8. `js/game.js` — creates `gameState` and the Phaser `Game` instance with `scene: [StartMenu, GameScene]`
+9. `js/dashboard.js` — welcome message, logout, and navigation to the leaderboard. Declared in `<head>` but `defer`red, so it runs *after* the plain body scripts above.
+10. `js/input-debug.js` — arrow-key diagnostics. Also `defer`red in `<head>`, and order-independent: it only defines `window.inputDebug` and reads `gameState` lazily, when one of its functions is called.
 
-Note that steps 2–7 are plain body `<script>` tags: they execute synchronously during parsing, and therefore before any deferred `<head>` script.
+Note that steps 2–8 are plain body `<script>` tags: they execute synchronously during parsing, and therefore before any deferred `<head>` script.
 
-`login.html` and `leaderboard.html` have no such subtlety — each loads a single deferred script (`js/login.js` / `js/leaderboard.js`), with `js/session-guard.js` first and blocking on the latter.
+`login.html` and `leaderboard.html` have no such subtlety — each loads `js/api.js` and then its own page script, both deferred and therefore in document order, with `js/session-guard.js` first and blocking on the latter.
 
 Navigation targets in these scripts (`window.location.href = "index.html"`, etc.) are page URLs, not script paths, so they stay unprefixed even though the scripts moved into `js/`.
 

--- a/index.html
+++ b/index.html
@@ -14,6 +14,7 @@
 </head>
 <body>
     <script src="https://cdn.jsdelivr.net/npm/phaser@3.16.2/dist/phaser.min.js"></script>
+    <script src="./js/api.js"></script>
     <script src="./js/board-data.js"></script>
     <script src="./js/touch-input.js"></script>
     <script src="./js/startmenu.js"></script>

--- a/js/api.js
+++ b/js/api.js
@@ -1,0 +1,21 @@
+// Every backend URL the frontend knows about. The host was written out five
+// times across three files, so changing backends meant finding all five and
+// getting all five right — and js/gamescene.js held two of them, in separate
+// bomb handlers that are easy to update one of and miss the other.
+//
+// Each path is built from API_BASE rather than repeated in full, so the host
+// appears exactly once in the codebase.
+//
+// This is still hardcoded, not configuration: there's no build step to
+// substitute an environment value, and a fetch from the browser needs a URL it
+// can reach, so a local backend means editing this line. That's the whole cost
+// now, and it's one line rather than five.
+//
+// Loaded on all three pages, ahead of anything that fetches.
+const API_BASE = "https://rave-mom-api.onrender.com/api/v1";
+
+const API = {
+    users: `${API_BASE}/users`,     // POST — signup
+    login: `${API_BASE}/login`,     // POST — returns the session token
+    scores: `${API_BASE}/scores`    // GET the top ten, POST a finished game
+};

--- a/js/gamescene.js
+++ b/js/gamescene.js
@@ -178,7 +178,6 @@ class GameScene extends Phaser.Scene {
 
         gameState.bomb1.on('animationcomplete', function() {
             [playerX, playerY] = getPlayerGridPosition(gameState.player)
-            const scoresURL = "https://rave-mom-api.onrender.com/api/v1/scores"
 
             if(isArrayInArray(BOARD.explosionPositions[randBomb1], [playerX, playerY]) && gameState.gameEnded === false) {
                 gameState.scoreText.x = 60
@@ -191,7 +190,7 @@ class GameScene extends Phaser.Scene {
                     }
                 }
 
-                fetch(scoresURL, {
+                fetch(API.scores, {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",
@@ -224,7 +223,6 @@ class GameScene extends Phaser.Scene {
 
         gameState.bomb2.on('animationcomplete', function() {
             [playerX, playerY] = getPlayerGridPosition(gameState.player)
-            const scoresURL = "https://rave-mom-api.onrender.com/api/v1/scores"
 
             if(isArrayInArray(BOARD.explosionPositions[randBomb2], [playerX, playerY]) && gameState.gameEnded === false) {
                 gameState.scoreText.x = 60
@@ -237,7 +235,7 @@ class GameScene extends Phaser.Scene {
                     }
                 }
 
-                fetch(scoresURL, {
+                fetch(API.scores, {
                     method: "POST",
                     headers: {
                         "Content-Type": "application/json",

--- a/js/leaderboard.js
+++ b/js/leaderboard.js
@@ -1,13 +1,11 @@
 const leaderboard = document.querySelector("#leaderboard")
 const returnToGameButton = document.querySelector("#return-to-game")
 
-const scoresURL = "https://rave-mom-api.onrender.com/api/v1/scores"
-
 returnToGameButton.addEventListener("click", event => {
     window.location.href = "index.html"
 })
 
-fetch(scoresURL, {
+fetch(API.scores, {
     headers: {
         "Authorization": `bearer ${localStorage.getItem("token")}`
     }

--- a/js/login.js
+++ b/js/login.js
@@ -1,6 +1,5 @@
 const userSignUp = document.querySelector("#new-user-signup")
 const signUpMessage = document.querySelector("#sign-up-message")
-const usersURL = "https://rave-mom-api.onrender.com/api/v1/users"
 
 localStorage.clear()
 
@@ -16,7 +15,7 @@ userSignUp.addEventListener("submit", event => {
         }
     }
 
-    fetch(usersURL, {
+    fetch(API.users, {
         method: "POST",
         headers: {
             "Content-Type": "application/json"
@@ -37,8 +36,6 @@ function displaySignUpMessage(response) {
 
 const userLogin = document.querySelector("#user-login")
 
-const loginURL = "https://rave-mom-api.onrender.com/api/v1/login"
-
 userLogin.addEventListener("submit", event => {
     event.preventDefault()
 
@@ -54,7 +51,7 @@ userLogin.addEventListener("submit", event => {
     // is a far worse thing to leak than a revocable token.
     localStorage.setItem("username", user.username)
 
-    fetch(loginURL, {
+    fetch(API.login, {
         method: "POST",
         headers: {
             "Content-Type": "application/json"

--- a/leaderboard.html
+++ b/leaderboard.html
@@ -8,6 +8,7 @@
     <link rel="stylesheet" href="./css/shared.css">
     <link rel="stylesheet" href="./css/leaderboard.css">
     <link rel="shortcut icon" type="image/png" href="assets/icons/favicon.png"/>
+    <script src="./js/api.js" defer></script>
     <script src="./js/leaderboard.js" defer></script>
     <title>Rave Mom</title>
 </head>

--- a/login.html
+++ b/login.html
@@ -6,6 +6,7 @@
     <link rel="stylesheet" href="./css/shared.css">
     <link rel="stylesheet" href="./css/login.css">
     <link rel="shortcut icon" type="image/png" href="assets/icons/favicon.png"/>
+    <script src="./js/api.js" defer></script>
     <script src="./js/login.js" defer></script>
     <title>Rave Mom</title>
 </head>


### PR DESCRIPTION
Collects every backend URL into `js/api.js`. **No behaviour change** — the three endpoints are byte-identical to the literals on `master`, verified.

## The problem

The API host was written out **five times across three files**:

```
js/login.js:3         .../api/v1/users
js/login.js:40        .../api/v1/login
js/leaderboard.js:4   .../api/v1/scores
js/gamescene.js:181   .../api/v1/scores
js/gamescene.js:227   .../api/v1/scores
```

Pointing the frontend at a different backend meant finding all five and getting all five right. The two in `js/gamescene.js` are the trap: separate `const scoresURL` declarations inside its two bomb handlers, which are near-identical blocks of code — exactly the shape where you update one and miss the other.

## The change

```js
const API_BASE = "https://rave-mom-api.onrender.com/api/v1";

const API = {
    users: `${API_BASE}/users`,
    login: `${API_BASE}/login`,
    scores: `${API_BASE}/scores`
};
```

Each path is built from `API_BASE`, so **the host appears exactly once in the codebase** and switching backends is a one-line edit.

Still hardcoded rather than configured, and deliberately: there's no build step to substitute an environment value, and a `fetch` from the browser needs a URL it can actually reach. The goal was to stop repeating the same string, not to invent a config system this repo has no way to feed.

## Loading it took two shapes

The pages differ, so the tag does too:

| Page | Tag | Why |
| --- | --- | --- |
| `index.html` | plain body script before `js/gamescene.js` | its consumer is a plain body script |
| `login.html` | `defer`, before `js/login.js` | deferred scripts run in document order, so it still wins |
| `leaderboard.html` | `defer`, before `js/leaderboard.js` | same |

Using `defer` on the two simpler pages keeps the critical path free of another blocking request, matching the reasoning already applied to `js/clear-stored-password.js`.

## Verification

All three pages exercised in a browser, not just read:

```
login.html        API defined, endpoints correct, login.js globals all present
leaderboard.html  API defined; fetch observed as a real network request to
                  https://rave-mom-api.onrender.com/api/v1/scores
index.html        API defined; script order api -> board-data -> touch-input
                  -> startmenu -> gamescene -> game
                  gamescene references API.scores twice, no scoresURL left
```

And the endpoints themselves, compared against the literals extracted from `master`:

```
API.users   .../api/v1/users    matches master
API.login   .../api/v1/login    matches master
API.scores  .../api/v1/scores   matches master
every master endpoint represented: true
ALL ENDPOINTS UNCHANGED
```

`grep -rn "onrender.com" js/` now returns `js/api.js` and nothing else.

## Docs

- `CLAUDE.md` tripwire **74 → 75**, plus the load-order entry.
- Rewrote the frontend/backend section, which documented the old scattering as a known cost ("backend URL changes require editing `js/login.js`, `js/leaderboard.js`, and `js/gamescene.js` directly") — no longer the state of things.

## Testing

Log in, play a round to a game over so the score POSTs, and open the leaderboard. Any load-order mistake would be loud and immediate — `API is not defined` at the fetch site.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
