### PR TITLE
⏳ feat: show progress while the backend wakes

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,25 @@ Two things to leave alone:
 
 Both forms show a failure message (`#login-error`, `#signup-error`). Before this existed a wrong password did nothing observable at all: the response has no token, `localStorage` coerced `undefined` to the string `"undefined"`, and the redirect guard declined to navigate without saying why. The `"undefined"` check in `js/session-guard.js` stays as a defence against storage written by those older builds, but nothing writes that value now.
 
+### Login page pending state
+The backend is on Render's free tier and spins down when idle, so the first request after that can take 20+ seconds. Two things address it, both in the login page's own files.
+
+`js/login.js` fires a **prewarm** on load: a tokenless GET to `API.scores` whose response is thrown away. The 401 it answers with is the expected result — what matters is only that a request reached Render, which is what starts the spin-up, and a 404 or even a CORS rejection would do just as well. `js/leaderboard.js` fetches the same URL *with* a token as a real scores request, so don't mistake one for the other, and don't remove the `.catch` — without it every page load can log an unhandled rejection for a failure that means nothing.
+
+While a request is in flight, the submit button and the switch prompt both collapse and an indeterminate progress bar takes their place — all driven by a `pending` class on the form. Load-bearing details:
+- **`display: none`, not `visibility`.** The form deliberately gets shorter and the card shrinks around it. This is the opposite choice from `css/game.css`, which uses `visibility` on its game-over buttons *to avoid* exactly that shift — the two want different things, so don't "fix" one to match the other.
+- **The bar carries its own `margin-top`** rather than living in a spacer element, so `[hidden]` removes the margin along with it and the form closes up completely when idle.
+- **The collapse is on the same `pending` class as the bar**, so the swap happens in one step. Tying it to the click instead would collapse the controls for `SHOW_DELAY_MS` before anything replaced them, and would flicker on a fast response that never shows a bar at all.
+- **Collapsing drops focus.** The player has usually just pressed Enter from the password field or clicked the button itself, so `js/login.js` moves focus to the indicator, which is `tabindex="-1"` and carries the `progressbar` role. Don't remove that `tabindex`.
+- **A hidden submit button does not stop a form submitting.** Enter in a text field still fires it, so the duplicate guard is the `active` check in the submit handler, and it engages the moment the request is sent rather than after the show delay — blocking a fast double-press during the window where nothing has visibly changed.
+- **Hiding the switch prompt means no form-swapping mid-request.** The two controllers are still fully independent, so simultaneous login and signup requests behave correctly — but the UI can no longer produce that state. Keep the independence anyway; it costs nothing and the alternative is shared mutable state between the forms.
+- **Every timer must be cleared on the way out.** There are two per form — the show delay and the ten-second waking threshold — and a survivor paints a bar or a "still waking" line onto a form with nothing in flight, the threshold one doing it ten seconds after the fact. `stop()` clears both unconditionally and is safe to call when idle, which is what lets `pageshow` call it on every page view.
+- **`pageshow` is the back-button fix.** A bfcache restore brings the DOM back exactly as it left, so without it a successful login followed by Back lands on a form with no button and a bar still running. Nothing at the top level of `js/login.js` re-runs on that restore — which is also why `localStorage.clear()` doesn't fire.
+
+There is deliberately **no request timeout**: on a backend that legitimately takes 50+ seconds to wake, one risks reporting failure on a login that was about to succeed. A hung request pends indefinitely and the waking message is what keeps that legible.
+
+The two timing values sit together at the top of `js/login.js`.
+
 `css/login.css` carries a `-webkit-autofill` override. Chrome's autofill background beats an ordinary `background-color`, and a saved credential is the most likely way these fields are ever seen — but autofill styling doesn't engage on typed input, so **testing by typing will not catch a regression here**.
 
 ### Stylesheets

--- a/_plans/login-pending-state.md
+++ b/_plans/login-pending-state.md
@@ -1,0 +1,226 @@
+# Plan: Login pending state
+
+Implements `_specs/login-pending-state.md`. **Written before implementation** —
+nothing here has been built or verified yet. Correct it in place once it ships,
+the way `_plans/touch-controls.md` was.
+
+## Context
+
+The backend is on Render's free tier and spins down when idle. Waking it takes
+long enough to look broken: a login submitted against a cold instance took over
+20 seconds during the previous change. For that whole window the page shows
+nothing at all, so a request in flight is indistinguishable from a click that
+didn't register — and the natural response, clicking again, fires a second
+request at an instance already struggling to wake.
+
+This works both ends of it. A prewarm request on page load starts the instance
+waking while the player is still typing, so the wait is shorter. An indeterminate
+progress indicator replaces the submit button while a request is in flight, so
+whatever wait is left is legible. Past ten seconds a message says the server is
+still waking, so a long wait reads as expected rather than as a hang.
+
+`_specs/login-form-toggle.md` deliberately left this out of scope once failure
+messages existed. Those fixed "nothing happened when it failed"; this fixes
+"nothing happens while it works".
+
+## Findings that shape the design
+
+| Finding | Consequence |
+| --- | --- |
+| `visibility: hidden` keeps an element's box; `display: none` collapses it | The button can be hidden with its space preserved exactly, so the slot needs no hardcoded height and nothing below can shift. `css/game.css:229` already chose `visibility` for the same class of reason. |
+| **Both** `visibility: hidden` and `display: none` drop focus and leave the tab order | Hiding the button strands a keyboard user regardless of which is used, so focus has to be moved deliberately. This is the common path, not the rare one — the player usually just pressed Enter from the password field. |
+| A hidden submit button does not stop a form submitting | Enter in a text field still fires `submit`. The duplicate guard has to live in the handler and cannot rely on the button being gone. |
+| `.form-message` carries `min-height: 16px` itself (`css/login.css:224`) | A second message element with the same class would reserve a second line. The `min-height` moves to a wrapper the two share. |
+| `js/leaderboard.js:8` already GETs `API.scores` **with** a token | The prewarm is a second, tokenless GET to the same URL whose result is discarded. Without a comment it reads as broken code. |
+| `js/touch-input.js` puts its two feel tunables together at the top | Precedent for where `SHOW_DELAY_MS` and `WAKING_MESSAGE_MS` belong. |
+
+## The part most likely to be got wrong
+
+**Timer leaks.** There are two timers per form and four in total — the delay
+before showing the indicator, and the ten-second waking threshold. Each has to be
+cleared when its request settles, when a successful signup switches the view, and
+on `pageshow`.
+
+The failure is quiet and delayed. A surviving threshold timer paints "still
+waking the server" onto a form with nothing in flight, ten seconds after the
+attempt that armed it — long enough after the cause that it looks like a ghost.
+The stacking case is worse: submit, fail, resubmit inside ten seconds, and the
+first attempt's timer fires during the second.
+
+Every timer handle lives on its form's pending controller, and `stop()` clears
+both unconditionally. `stop()` must be safe to call when nothing is pending,
+because `pageshow` calls it on every page view.
+
+## Approach
+
+### 1. `login.html` — a submit slot and a shared message slot
+
+Per form, wrap the submit button so the indicator can sit over it:
+
+```html
+<div class="submit-slot">
+    <input type="submit" value="Login" id="user-login-submit" class="form-field">
+    <div class="progress" id="login-progress" role="progressbar" tabindex="-1"
+         aria-label="logging in" hidden>
+        <div class="progress-bar"></div>
+    </div>
+</div>
+```
+
+- `role="progressbar"` with **no `aria-valuenow`** is what marks it indeterminate.
+- `tabindex="-1"` makes it a programmatic focus target — see focus handling below.
+- `hidden` as the resting state, so a script that never runs leaves a plain button.
+
+Then replace the single message paragraph with a slot holding both:
+
+```html
+<div class="form-message-slot">
+    <p id="login-error" class="form-message" role="alert"></p>
+    <p id="login-status" class="form-message form-status" role="status"></p>
+</div>
+```
+
+`role="alert"` stays assertive for failures; `role="status"` is polite, which is
+right for "things are fine, just slow". They never hold text at the same time, so
+they share one reserved line.
+
+Same three additions on the signup form, with `signup-` ids.
+
+### 2. `css/login.css` — the indicator
+
+- `.submit-slot { position: relative }`. The button keeps its normal flow;
+  `.progress` is absolutely positioned to fill the slot.
+- `form.pending .form-field[type="submit"] { visibility: hidden }` — box
+  preserved, so the slot's height is still the button's height and nothing below
+  moves. No magic number.
+- `form.pending .progress` becomes visible (drop `hidden` via the attribute or a
+  class — `[hidden]` needs `display` care since the element is flex).
+- Track and bar: track in `#3d3d3d` with the `#5a5a5a` border and 8px radius the
+  fields already use, bar in greenyellow.
+- The animation translates the bar across the track on a loop, using
+  **`steps()`** rather than linear easing — chunky discrete movement reads as
+  deliberate against Press Start 2P and the pixel art, where a smooth
+  Material-style sweep would look borrowed.
+- Move `min-height: 16px` from `.form-message` to `.form-message-slot`.
+- `.form-status` in white rather than the failure red — it is not an error.
+- `@media (prefers-reduced-motion: reduce)`: no animation. The bar holds a
+  **partial** static width, never full, so it can't read as "complete", and the
+  waking message is surfaced immediately instead of at ten seconds so text
+  carries the meaning the motion would have.
+
+### 3. `js/login.js` — the pending controller
+
+Two tunables at the top of the file, together:
+
+```js
+const SHOW_DELAY_MS = 250       // below this, the indicator would only flicker
+const WAKING_MESSAGE_MS = 10000 // past this, a wait needs explaining
+```
+
+A factory per form keeps the two independent, which the spec requires, without
+duplicating the logic:
+
+```js
+const loginPending = pendingFor(userLogin, loginProgress, loginStatus)
+const signUpPending = pendingFor(userSignUp, signUpProgress, signUpStatus)
+```
+
+`pendingFor` closes over its form's elements and its two timer handles and
+returns `{ start, stop, active }`:
+
+- `start()` — sets `active`, arms both timers. The show timer adds the `pending`
+  class, unhides the indicator, and **moves focus to it**. The threshold timer
+  writes the waking message.
+- `stop()` — clears both timers unconditionally, clears `active`, removes the
+  class, re-hides the indicator, empties the status. Safe to call when idle.
+
+**Focus.** When the indicator appears, focus moves to it — it is the element
+describing the state, and Tab from there continues to the switch prompt below.
+Without this the player lands on the document body and Tab restarts at the top.
+
+**Guards.** Each submit handler, after `preventDefault()`, returns early if its
+controller is already `active`. `start()` is called immediately — not after the
+show delay — so a fast double-press is blocked during the window where nothing
+has visibly changed.
+
+**Wiring.**
+- Login: `stop()` on both failure branches; **not** on success, since the page is
+  navigating and releasing would flash the button back.
+- Signup: `stop()` on failure, and on success as part of switching to the login
+  view — otherwise toggling back later finds a form with no button and a bar
+  still running.
+- `window.addEventListener("pageshow", …)` calls `stop()` on both. This is the
+  bfcache fix: the restored DOM keeps whatever state it had, and nothing at the
+  top level of the file re-runs, so `localStorage.clear()` doesn't fire either.
+
+**Prewarm**, near the top, commented so it isn't mistaken for a scores fetch:
+
+```js
+fetch(API.scores).catch(() => {})
+```
+
+Tokenless, so it answers 401 — which is fine, because the response is ignored
+entirely. All that matters is that a request reached Render, which is what starts
+the spin-up. The `.catch` swallows the CORS and offline cases; without it every
+login page load can log an error for a request whose failure means nothing.
+
+### 4. `CLAUDE.md`
+
+- **The deploy tripwire stays at 77.** No new files — everything lands in the
+  four that exist. Worth stating so nobody bumps it by reflex.
+- A short subsection under the login page notes: the `pending` class, the two
+  tunables and where they live, why the button is hidden with `visibility`, and
+  that the prewarm's 401 is expected.
+
+## File changes
+
+| File | Change |
+| --- | --- |
+| `login.html` | submit slot + indicator + status element, both forms |
+| `css/login.css` | indicator and keyframes, `pending` rules, message slot, reduced-motion |
+| `js/login.js` | tunables, `pendingFor`, guards, `pageshow`, prewarm |
+| `CLAUDE.md` | pending model; tripwire explicitly unchanged |
+
+## Verification
+
+Serve with `lite-server` or `python3 -m http.server` from the repo root.
+
+**The timing paths, which is where the bugs are.** Temporarily drop
+`WAKING_MESSAGE_MS` to ~1000 to exercise the threshold quickly, then restore it
+and confirm once against a **real** cold start — let Render idle ~15 minutes, then
+submit and watch the indicator run past 30 seconds with the message appearing on
+schedule.
+
+- A warm request settles inside the show delay: indicator never appears, button
+  never moves.
+- A slow request: indicator appears, then the message at the threshold.
+- **Timer leak** — complete an attempt, then sit on the idle form for 15 seconds.
+  Nothing may appear.
+- **Stacking** — submit, fail, resubmit within ten seconds. The first attempt's
+  timer must not fire during the second.
+
+**The rest:**
+- Double-press and Enter-spam during pending → exactly one POST in the network
+  panel, not counting the prewarm.
+- Failure → indicator stops, button returns, message shows, retry works without
+  reloading.
+- Successful login → reaches `index.html` with the button never reappearing.
+- Successful signup → switches to login, and toggling back shows a normal signup
+  button with no bar.
+- **bfcache** — log in successfully, press Back. The login form must have its
+  button, no bar, no message, no armed timer.
+- Empty form → native validation, no pending state entered.
+- Both forms pending at once → neither affects the other.
+- Prewarm on load → one GET to `/scores`, no `Authorization` header, 401, no
+  console error. Confirm nothing is created by loading the page.
+- `prefers-reduced-motion` via DevTools rendering emulation → no animation, state
+  still legible, bar not reading as complete.
+- Screen reader → progress announced without a percentage; the waking message
+  announced politely, not as an alert.
+- 390px (DevTools device mode — Chrome won't resize a window below 500px):
+  nothing shifts when the button is swapped, and the message wording fits.
+
+**Deploy.** `firebase --version` current first — an old CLI reports
+`found 0 files` and publishes an empty site behind a green tick. Output must
+still read **77 files**, `/login.html` 200, and `/CLAUDE.md`, `/.git/config`,
+`/_specs/…`, `/_plans/…` all 404.

--- a/_plans/login-pending-state.md
+++ b/_plans/login-pending-state.md
@@ -1,8 +1,13 @@
 # Plan: Login pending state
 
-Implements `_specs/login-pending-state.md`. **Written before implementation** —
-nothing here has been built or verified yet. Correct it in place once it ships,
-the way `_plans/touch-controls.md` was.
+Implements `_specs/login-pending-state.md`. **Built and verified**, and corrected
+in place afterwards — so this reflects what shipped, including the one thing the
+plan designed itself into a corner on.
+
+The plan held up on the parts it called risky: the timer discipline, the
+`pageshow` fix, and the guard living in the submit handler were all right, and
+the bfcache case behaved exactly as predicted. What it got wrong was the
+indicator's *shape* — see "What changed during review" at the end.
 
 ## Context
 
@@ -218,9 +223,49 @@ schedule.
 - Screen reader → progress announced without a percentage; the waking message
   announced politely, not as an alert.
 - 390px (DevTools device mode — Chrome won't resize a window below 500px):
-  nothing shifts when the button is swapped, and the message wording fits.
+  nothing shifts when the bar appears, and the message wording fits.
 
 **Deploy.** `firebase --version` current first — an old CLI reports
 `found 0 files` and publishes an empty site behind a green tick. Output must
 still read **77 files**, `/login.html` 200, and `/CLAUDE.md`, `/.git/config`,
 `/_specs/…`, `/_plans/…` all 404.
+
+## What changed during review
+
+**The indicator does not cover the button.** The plan had it absolutely
+positioned over the submit button's box, with the button hidden by
+`visibility: hidden` — chosen because that preserves the box, so the slot needed
+no hardcoded height. It worked exactly as designed and looked wrong: a bar the
+full height of a button reads as a button, and it competed with the real one for
+attention.
+
+What shipped is a 13px bar — a third the button's height — that takes no space at
+all until a request starts, at which point **both the submit button and the switch
+prompt collapse** and the bar appears in their place. The card gets shorter.
+
+- **The height reservation went away entirely.** The plan's whole layout argument
+  was about not shifting; the shipped design shifts on purpose. Once the controls
+  collapse there is nothing to protect, so `display: none` replaced
+  `visibility: hidden` and the spacer element was deleted. The bar carries its own
+  `margin-top` instead, so `[hidden]` takes the margin with it.
+- **This is the opposite choice from `css/game.css`**, which uses `visibility`
+  specifically to avoid a shift. Both are right for their own page; neither should
+  be "fixed" to match the other.
+- **The collapse is driven by the same `pending` class as the bar.** Doing it on
+  the click instead would empty the form for `SHOW_DELAY_MS` before anything
+  replaced it, and would flicker on a fast response that shows no bar at all.
+- **Hiding the switch prompt narrowed the spec.** The spec had required the toggle
+  to stay usable mid-request; it doesn't. That makes two of its nastiest edge
+  cases unreachable through the UI — a response landing on a hidden form, and two
+  requests pending at once — but the per-form controllers stay independent anyway,
+  since the alternative is shared state and the isolation is free.
+
+An intermediate version left the button visible and used `aria-disabled` instead.
+That was discarded, but it surfaced something worth keeping in mind: the focus
+move to the indicator is not only a focus rescue. It is also what announces the
+pending state to a screen reader, because a bar appearing is otherwise a purely
+visual event. Remove the hiding and you lose the announcement with it.
+
+The lesson is narrow: the plan optimised the layout mechanics of an overlay
+before anyone had looked at whether an overlay was the right *shape*. The
+mechanics turned out to be reusable; the shape did not survive one screenshot.

--- a/_specs/login-pending-state.md
+++ b/_specs/login-pending-state.md
@@ -1,0 +1,398 @@
+# Spec for login-pending-state
+
+branch: claude/feature/login-pending-state
+
+## Summary
+
+The backend runs on Render's free tier, which spins the instance down when idle.
+The first request after that wakes it, and waking takes a long time — a wrong
+password submitted against a cold instance took **over 20 seconds** to come back
+during the login-form-toggle work, and Render's own documentation puts cold
+starts near a minute in the worst case.
+
+For that whole window the login page does nothing. The button stays lit, the
+message slot stays empty, and there is no way to tell a request in flight from a
+click that didn't register. The likely player response is to click again, or to
+decide the game is broken and leave — and the second click is the more damaging
+one, since it fires a second request against an instance that is already
+struggling to wake.
+
+This adds a pending state: on submit, the submit button gives way to a linear
+indeterminate progress indicator, and no further submission is accepted until the
+request settles. Past about ten seconds a message explains that the server is
+still waking, so a long wait reads as expected rather than as a hang. It's the
+follow-on that `_specs/login-form-toggle.md` deliberately left out of scope once
+failure messages existed — the messages fixed "nothing happened when it failed",
+and this fixes "nothing happens while it works".
+
+Both forms get it. Signup POSTs to the same cold instance and has exactly the
+same problem.
+
+Alongside it, the page **starts waking the backend as soon as it loads**, rather
+than waiting for the player to submit. Render begins spinning an instance up when
+the first request arrives, and a player spends several seconds typing a username
+and password before they submit — time the instance could already be using to
+wake. So this change works both ends of the problem: the prewarm shortens the
+wait, and the pending state explains whatever wait is left.
+
+## Functional Requirements
+
+### Entering the pending state
+
+- On submit, the form enters a pending state before the request goes out.
+- **The submit button is hidden and a linear indeterminate progress indicator
+  takes its place**, in the same spot, for as long as the request is in flight.
+  The button is not relabelled and not greyed — it is replaced.
+- **The indicator waits a short beat before appearing.** Against a warm instance
+  the whole request can settle in under 200ms, and a bar that appears and
+  vanishes inside a couple of frames reads as a glitch rather than as progress.
+  If the request settles within that beat, the indicator never appears at all and
+  the button never moves. A delay before showing is preferred over a minimum
+  display time because it can only ever shorten the interruption, never extend a
+  wait that has already finished.
+- The submit guard does **not** wait for that beat. It engages the instant the
+  request is sent, so a fast double-press is blocked even during the window where
+  nothing has visibly changed yet.
+- Hiding the button is what stops a second click. A control that isn't there
+  can't be pressed twice, and Enter in a field must be blocked on the same state,
+  since a hidden submit button does not stop a form from submitting.
+- An **indeterminate** indicator is the right kind precisely because the duration
+  is unknowable from the client: a warm instance answers in well under a second
+  and a cold one can take the better part of a minute. Nothing on the page can
+  tell which is happening, so nothing should imply a percentage or an ETA.
+- Any failure message left over from a previous attempt clears as it enters —
+  `js/login.js` already clears it at the top of each submit handler, and that
+  behavior stays.
+- Native validation runs first. A form that fails `required` or `minlength` never
+  fires its submit handler, so an empty form must not enter the pending state or
+  leave a stuck button behind.
+
+### Leaving the pending state
+
+**The indicator's lifetime is the request's lifetime.** It starts when the
+request is sent and stops when that request settles — not on a timer, and not
+after a fixed number of seconds. A fixed duration would be wrong in both
+directions: it would keep animating long after a fast response had already come
+back, and it would stop while a slow cold start was still genuinely in progress,
+which is the exact moment the player most needs to see it. (A fixed-duration
+*give-up* is a different mechanism — see the timeout question in Open Questions.)
+
+- **On failure** — a rejected credential, a duplicate username, or a request that
+  never completed — the indicator stops, the button comes back, and the existing
+  failure message appears. The player must be able to retry without reloading.
+- **On successful login** the page navigates to `index.html`. The indicator keeps
+  running through that, because the work genuinely isn't finished — stopping it
+  would flash the button back for a frame on a page that's leaving.
+- **On successful signup** the view switches to the login form. The signup form's
+  indicator must stop and its button return as part of that, or switching back
+  later finds a form with no submit button and a bar still animating on it.
+- Both forms track their own state. A login in flight must not disable the signup
+  button, or vice versa.
+
+### The waking message
+
+- If a request is still in flight after roughly **10 seconds**, a message appears
+  saying the server is still waking up. The indicator alone confirms something is
+  happening; past ten seconds the player needs to know *why* it is taking this
+  long, and that the wait is expected rather than a hang.
+- It is a **status, not an error** — the wording should read as an explanation,
+  and it must not be written into the existing `role="alert"` elements, which are
+  assertive and reserved for failures. A screen reader interrupting with an alert
+  to say things are fine is the wrong signal.
+- It clears when the request settles, in every outcome — success, failure, or a
+  view switch. A failure message replacing it must not leave both on screen.
+- It can share the reserved message line with the failure message rather than
+  claiming a second one, because the two are mutually exclusive: the failure slot
+  is cleared on submit and only refills once the request has settled, by which
+  time this message is gone.
+- Both the delay before showing the indicator and this threshold are **timing
+  values that belong together in one named place**, the way `DEAD_ZONE` and
+  `HYSTERESIS` sit at the top of `js/touch-input.js`. They are the two numbers
+  anyone tuning this will want to find.
+
+### Restoring from the back/forward cache
+
+- Both forms are reset to their normal, usable state whenever the page is shown,
+  including when it is restored from the browser's back/forward cache — buttons
+  back, indicators stopped, waking message cleared, **and both pending timers
+  cancelled**. The `pageshow` event is what covers the restore case; an ordinary
+  load has nothing pending, so resetting unconditionally on every show is a no-op
+  there and needs no special-casing.
+- This is not optional polish. Without it, a successful login followed by the
+  back button lands the player on a login page with no submit button, a bar
+  animating forever, and no way to recover but a manual reload.
+
+### While pending
+
+- The view toggle ("Don't have an account? Sign up") stays usable. A player who
+  gets bored waiting is allowed to go look at the other form.
+- Consequently the response can arrive while its form is hidden. Whatever it does
+  — release the button, show a message, switch views — must not yank the player
+  out of the form they're now looking at, and must leave both forms in a
+  coherent state.
+- The password reveal stays usable; it's a rendering toggle with no bearing on
+  the request.
+- The fields themselves may stay editable. Nothing depends on them after the
+  request body is built, and freezing them adds a state to unwind for no gain.
+
+### Warming the backend on page load
+
+- When `login.html` loads, the page fires one request at the backend for the sole
+  purpose of starting the instance waking. It is sent as early as the page script
+  runs, so the wake overlaps with the player typing.
+- **It is a GET to `API.scores` with no `Authorization` header**, which answers
+  401. That is a fine outcome — the point is that the request reached Render, not
+  what came back.
+- This **needs a comment saying so.** `js/leaderboard.js` already GETs the same
+  URL, with a token, as a real scores fetch. Without a note, the next reader finds
+  a second, tokenless call to the scores endpoint whose result is thrown away and
+  reasonably concludes it is broken.
+- **The response is ignored entirely** — status code, body, and all. What matters
+  is only that a request reached Render's router, which is what triggers the spin
+  up. A 401, a 404, a 405, or a CORS rejection all wake the instance just as well
+  as a 200, so none of them is a failure for this purpose.
+- **It must be a safe request with no side effects.** A GET, not a POST — it must
+  not create a user, a score, or a session. It sends no credentials.
+- It is completely silent. It never shows a message, never touches either
+  button's state, never counts as the pending state, and never writes anything to
+  storage.
+- **Its failure must be swallowed**, including the CORS case. An uncaught
+  rejection here would put an error in the console on every single visit to the
+  login page, on a request whose failure is genuinely of no consequence.
+- A real submit that happens while the prewarm is still in flight proceeds
+  normally. The two are independent; the prewarm is never awaited and never
+  blocks or delays a submit.
+- Only `login.html` does this. `index.html` and `leaderboard.html` already hold a
+  session and talk to the API on their own.
+
+### Accessibility
+
+- The indicator is exposed to assistive technology as an indeterminate progress
+  indicator — announced as in-progress, with **no percentage or value**, since
+  there is none to report. A bar that is only a moving graphic tells a screen
+  reader user nothing.
+- The waking message is a polite status, announced without interrupting. It is
+  separate from the `role="alert"` failure elements even if it shares their space
+  on screen.
+- **It must respect `prefers-reduced-motion`.** A continuously looping animation
+  is precisely what that setting exists to suppress, and it can cause real
+  discomfort. Under it the pending state still has to be conveyed — a static
+  indicator, or text — rather than simply disappearing and leaving those players
+  back where this spec started, with a page that looks like it did nothing.
+- **Disabling the button while it holds focus drops focus to the document body**
+  in most browsers, which strands a keyboard user mid-form and sends them back to
+  the top on the next Tab. Whatever mechanism is used has to keep the player
+  somewhere sensible.
+- The existing message elements are `role="alert"`, which is assertive and
+  correct for a failure. A progress announcement is a *status*, not an alert, and
+  should not interrupt with the same urgency — it needs its own treatment rather
+  than being written into the alert element.
+
+### Visual
+
+- The indicator occupies **exactly the space the button vacates**, so swapping one
+  for the other shifts nothing. The button is `.form-field`: full width, 8px
+  corners, and a known height. Reserving that box is what keeps the failure
+  message and the "Don't have an account?" prompt below it from jumping.
+- It is built in CSS — an animated bar, no image, no library, nothing to load.
+  This matters more than usual here: an indicator that had to be fetched from the
+  network would be racing the very request whose slowness it exists to explain.
+- It should read as part of the game's look rather than a stock component
+  dropped in — greenyellow on the card's black is the palette already in use, and
+  the pixel aesthetic argues for hard edges over a soft gradient sweep.
+- It stays distinguishable from the grey text fields above it, which are `#3d3d3d`
+  with a `#5a5a5a` border.
+
+### Constraints carried over
+
+- No build step, no bundler, no new dependencies. Plain HTML/CSS/JS in the
+  existing files.
+- The password still goes into the request body and nowhere else. This change
+  touches button state only and must not introduce any new persistence.
+- `js/login.js` still clears all of `localStorage` on load.
+- `.form-field` keeps a font size no smaller than 16px, and the rules for the two
+  submit buttons must stay scoped so they don't leak onto the text inputs — see
+  the input-type scoping already in `css/login.css`.
+
+## Possible Edge Cases
+
+- **The back button restores a stuck pending button.** After a successful login
+  the page navigates to `index.html`; pressing Back can restore `login.html` from
+  the browser's back/forward cache with its DOM exactly as it left — button
+  disabled, still reading as in-flight, and unusable. A bfcache restore does not
+  re-run the script, so `localStorage.clear()` at the top of `js/login.js` does
+  not fire either. This is the most likely way a real player meets a permanently
+  dead login button. Handled by the `pageshow` reset above; the reason it needs
+  its own mechanism is precisely that no code at the top level of the file runs
+  again.
+- **A "backend is booted" flag in storage does not address this**, and is worth
+  recording as considered and rejected so it isn't re-proposed. The stuck button
+  is restored DOM state, not a wrong belief about the backend — knowing the
+  instance was warm would not re-enable it. It would also be wiped by the
+  `localStorage.clear()` on every login-page load, go stale silently once Render
+  idles the instance out (~15 minutes), and cache a server-side global fact in
+  one player's browser where it says nothing about whether the instance is awake
+  right now. It fails in the worst direction too: wrongly believing the backend
+  is warm would suppress reassurance exactly when the wait is longest.
+- **A response arriving after the player switched forms.** Covered above, but
+  worth restating as the case most likely to produce a visible glitch: focus
+  moving, or a message appearing on a form nobody is looking at.
+- **Two requests in flight across the two forms.** Submit login, toggle to
+  signup, submit signup — both are pending at once. Neither may release or
+  message the other's form.
+- **The waking message can appear on a hidden form.** The player submits, waits,
+  toggles to the other form, and ten seconds later the message lands on a form
+  nobody is looking at — while the form they *are* looking at says nothing about
+  the request still running.
+- **Double submit in the same tick.** Two Enter presses in quick succession, or a
+  double-click, can both dispatch before a disable applied inside the handler
+  takes effect. The guard needs to hold for the very first repeat, not just the
+  second.
+- **Enter inside a text field** submits the form the same as clicking, so it has
+  to go through the identical path.
+- **A cold start is long enough to look broken anyway.** Twenty-plus seconds of a
+  button reading "logging in…" may still read as hung. Whether to say something
+  more after a threshold is an open question below, but the plain pending state
+  is the floor.
+- **Autofill plus immediate submit.** A password manager can fill and submit
+  faster than a person, which is the tightest timing the guard will see.
+- **A hidden submit button does not stop the form submitting.** Pressing Enter in
+  a text field still fires submit even with no visible button, so the guard has to
+  live in the submit handler and not rely on the button being gone.
+- **Hiding the button drops focus.** `display: none` on the focused element sends
+  focus to the document body — and the player has very likely just pressed Enter
+  from the password field or clicked the button itself, so this is the common
+  path, not the rare one. Note `css/game.css` already prefers `visibility` over
+  `display` for a related reason; the same choice matters here for a different
+  one.
+- **A leaked timer fires onto an idle form.** There are now two timers per form —
+  the show delay and the 10-second threshold — and four in total. Every one of
+  them has to be cancelled when its request settles, when the view switches on a
+  successful signup, and on `pageshow`. A surviving timer paints an indicator or
+  a "still waking" message onto a form that has nothing in flight, and the
+  threshold one does it ten seconds after the fact, long after any obvious cause.
+- **A second submit must not stack timers.** Submitting, failing, and submitting
+  again inside ten seconds must not leave the first attempt's threshold timer
+  running to fire during the second.
+- **A hung request pends forever, by decision.** With no timeout, a connection
+  that stalls without erroring leaves the indicator running indefinitely. This is
+  accepted: on a backend that legitimately takes 50+ seconds to wake, a timeout
+  risks calling failure on a login that was about to succeed. The waking message
+  is what makes the state legible in the meantime, and a reload is the escape
+  hatch. Worth knowing it is a decision and not an oversight.
+- **`prefers-reduced-motion` must not silently remove the feedback.** Suppressing
+  the animation and leaving nothing behind returns those players to exactly the
+  problem this spec exists to fix.
+- **The prewarm makes the login page talk to the backend unprompted.** Anyone
+  watching the network panel will see a request they didn't ask for, and it now
+  happens on a page a logged-out stranger can load. It must stay a plain,
+  credential-free GET so that is all it ever is.
+- **A CORS-blocked prewarm still works but looks broken.** The browser sends the
+  request — so the instance wakes — then blocks the *response* and rejects the
+  promise. The wake succeeds and the console reports a failure, which is exactly
+  backwards from how it reads. Worth knowing before someone "fixes" it.
+- **The prewarm keeps a free-tier instance awake more of the time.** Every visit
+  to the login page now counts as traffic. That is the point, but it does consume
+  more of the free tier's budget than before, and a bot crawling the login page
+  would wake the backend repeatedly.
+- **The prewarm cannot fully close the gap.** A player who autofills and submits
+  instantly gives it no head start at all, and a cold start can outlast the
+  typing regardless. The pending state still has to carry that case — the prewarm
+  shortens the wait, it does not remove it.
+- **A prewarm still in flight at submit time** must not be mistaken for the
+  submit's own request when checking that no duplicate login was sent.
+
+## Acceptance Criteria
+
+- Submitting the login form immediately hides the button and shows an animating
+  indicator in its place, before any response arrives.
+- The indicator runs for as long as the request does — confirmed by watching a
+  genuine cold start run past 30 seconds with it still animating, and a warm
+  request stop it promptly. It is never on a fixed timer.
+- A request that settles inside the show delay never displays the indicator at
+  all, and the button never moves.
+- A request still running at ~10 seconds shows the waking message; one that
+  settles before then never does.
+- The waking message clears on success, on failure, and on a signup view switch —
+  never left on screen beside a failure message.
+- Submitting, failing, and resubmitting inside ten seconds does not fire the first
+  attempt's threshold timer during the second attempt.
+- After any completed attempt, waiting 15 seconds on an idle form produces no
+  stray indicator and no stray message.
+- Pressing Enter in a field while pending sends no second request — verifiable as
+  a single login entry in the network panel, not counting the page-load prewarm.
+- On a failed login the indicator stops, the button returns, and "login failed"
+  appears. A second attempt works without reloading.
+- On a successful login the page reaches `index.html` with the button never
+  having reappeared.
+- On a failed signup the indicator stops, the button returns, and "signup failed"
+  appears.
+- On a successful signup the view switches to login **and** the signup button is
+  back to normal — confirmed by toggling back to it.
+- With the backend unreachable, both buttons recover rather than sticking.
+- Submitting an empty form triggers native validation and leaves the button
+  untouched and usable.
+- A login and a signup can be pending simultaneously without affecting each
+  other's button.
+- Pressing Back after a successful login lands on a login form with its button
+  present and usable, no indicator running, no waking message, and no timer left
+  armed.
+- The prewarm is a GET to `API.scores` sent with no `Authorization` header, and
+  its 401 is ignored.
+- The pending state is announced to assistive technology as indeterminate
+  progress, with no percentage, and a keyboard user Tabbing after submit is
+  somewhere sensible rather than back at the top of the document.
+- With `prefers-reduced-motion: reduce` set, the animation stops but the pending
+  state is still conveyed — the page must not look idle.
+- Nothing resizes or shifts when the button is swapped for the indicator, at both
+  desktop and 390px. The failure message and the switch prompt below stay put.
+- The indicator needs no network request of its own — verifiable by watching the
+  network panel show nothing but the login POST.
+- Loading `login.html` fires exactly one prewarm request, visible in the network
+  panel before the player types anything.
+- The prewarm leaves no trace in the UI: no message, no button state, nothing
+  written to storage.
+- With the backend unreachable, or with CORS rejecting the prewarm response, the
+  console stays clean — no unhandled rejection from the prewarm on any page load.
+- The prewarm is a GET and creates nothing. Confirm no user, score, or session is
+  created by simply loading the login page.
+- A submit fired while the prewarm is still in flight completes normally.
+- No JavaScript errors on load, on submit, on failure, or on toggling views
+  mid-request.
+
+## Open Questions
+
+Resolved during review: the pending state is a **linear indeterminate progress
+indicator shown in place of the hidden submit button**, tied to the request's
+lifetime rather than a fixed duration. This supersedes the earlier decision to
+grey the button out — the two are alternatives, not layers, and the indicator is
+the stronger of them because it says "something is happening" where a grey button
+only says "you can't press this." The **backend prewarm on page load is also in
+scope for this change**, not deferred to its own spec.
+
+Also resolved: a **waking message after ~10 seconds** is in scope; a **short
+delay before the indicator appears** is in scope; **signup gets the full
+treatment** alongside login; the prewarm is a **tokenless GET to `API.scores`**;
+and there is **no request timeout** — a hung request pends indefinitely, which is
+a deliberate trade against calling failure on a slow login that was about to
+succeed.
+
+Deferred to its own change:
+
+- **Distinguishing an unreachable backend from a wrong password.** Both say
+  "login failed" today, deliberately. The waking message makes the gap more
+  visible rather than less — a player can now watch it say the server is waking
+  and then be told the login failed, with no way to tell whether their password
+  was wrong or the backend never came up. Worth revisiting, but it is a change to
+  what the failure messages mean and belongs on its own.
+
+Still open:
+
+- **The two timing values.** ~10 seconds for the waking message and a short beat
+  before the indicator are both starting points, not measured. The threshold in
+  particular wants checking against a real cold start: too early and it fires on
+  ordinary waits, too late and the player has already given up.
+- **The waking message's wording.** "still waking the server…" is the working
+  text. Press Start 2P is wide and this is the longest string on the card, so it
+  may need shortening — especially at the 560px breakpoint where the type steps
+  down.

--- a/_specs/login-pending-state.md
+++ b/_specs/login-pending-state.md
@@ -124,12 +124,18 @@ which is the exact moment the player most needs to see it. (A fixed-duration
 
 ### While pending
 
-- The view toggle ("Don't have an account? Sign up") stays usable. A player who
-  gets bored waiting is allowed to go look at the other form.
-- Consequently the response can arrive while its form is hidden. Whatever it does
-  — release the button, show a message, switch views — must not yank the player
-  out of the form they're now looking at, and must leave both forms in a
-  coherent state.
+- **Superseded during implementation.** This section originally required the view
+  toggle to stay usable while a request was in flight, so a player who got bored
+  could go look at the other form. It ships hidden instead: the switch prompt
+  collapses along with the submit button, and the bar stands in for both.
+- The cost is real and worth stating. A player cannot reach the signup form while
+  a login is waking the server, and since there is no timeout, a hung request
+  leaves them with no route to the other form short of reloading.
+- What this buys is that the messiest cases below stop being reachable through
+  the UI at all — a response landing on a form nobody is looking at, and two
+  requests in flight at once. **The two controllers stay independent regardless**,
+  because that costs nothing and the alternative is shared state between the
+  forms.
 - The password reveal stays usable; it's a rendering toggle with no bearing on
   the request.
 - The fields themselves may stay editable. Nothing depends on them after the
@@ -240,10 +246,10 @@ which is the exact moment the player most needs to see it. (A fixed-duration
 - **Two requests in flight across the two forms.** Submit login, toggle to
   signup, submit signup — both are pending at once. Neither may release or
   message the other's form.
-- **The waking message can appear on a hidden form.** The player submits, waits,
-  toggles to the other form, and ten seconds later the message lands on a form
-  nobody is looking at — while the form they *are* looking at says nothing about
-  the request still running.
+- **The waking message landing on a hidden form** — the player submits, toggles
+  away, and ten seconds later the message appears where nobody is looking. **No
+  longer reachable through the UI** now that the switch prompt collapses while
+  pending, but it would come straight back if the toggle were ever restored.
 - **Double submit in the same tick.** Two Enter presses in quick succession, or a
   double-click, can both dispatch before a disable applied inside the handler
   takes effect. The guard needs to hold for the very first repeat, not just the

--- a/css/login.css
+++ b/css/login.css
@@ -140,12 +140,13 @@ input[type="password"].form-field:-webkit-autofill {
 /* The focused state is a border now rather than a box-shadow, so the autofill
    rule above no longer competes with it and needs nothing restated here. */
 
-/* Separates the submit from the last field. Without it the button butts against
-   the password field and reads as a third input rather than the action that
-   ends the form. Scoped by input type like the rules above, so it can't add a
-   gap between the text fields. */
+/* Separates the submit from what precedes it — the progress strip, which in turn
+   sits below the password field. Without a gap the button butts against them and
+   reads as another input rather than the action that ends the form. Scoped by
+   input type like the rules above, so it can't add a gap between the text
+   fields. */
 input[type="submit"].form-field {
-    margin-top: 20px;
+    margin-top: 8px;
 }
 
 .password-wrap {
@@ -218,18 +219,102 @@ input[type="submit"].form-field {
     display: block;
 }
 
-/* `min-height` reserves the line whether or not there's a message, so text
-   appearing doesn't shove the switch prompt below it downward — under a thumb
+/* Both the submit button and the switch prompt collapse while a request is in
+   flight, so the bar isn't a third thing competing with them — it stands in for
+   the pair.
+
+   `display`, not `visibility`: the form deliberately gets shorter, and the card
+   shrinks around it. That is a layout shift by choice — `visibility` would keep
+   both boxes and leave two empty gaps where the controls were. Note this differs
+   from css/game.css, which uses `visibility` precisely to avoid the shift; the
+   two want opposite things.
+
+   Driven by the same `pending` class as the bar, so the swap happens in one
+   step. Gating it on the click instead would collapse the button for
+   SHOW_DELAY_MS before anything replaced it, and would flicker on a fast
+   response that never shows a bar at all. */
+form.pending input[type="submit"].form-field,
+form.pending .form-switch {
+    display: none;
+}
+
+/* A third the height of the button it replaces: enough to read as a progress
+   bar, not so much that it stands in as one. The 4px radius is deliberately
+   smaller than the 8px used on the fields and buttons — at this height 8px would
+   round the ends into a pill.
+
+   The margin is on the bar rather than a wrapper so it costs nothing when idle:
+   `[hidden]` takes the element out of the flex column entirely, margin included,
+   and the form closes up as though it were never there. */
+.progress {
+    height: 13px;
+    margin-top: 28px;
+    overflow: hidden;
+    border: 2px solid #5a5a5a;
+    border-radius: 4px;
+    background-color: #3d3d3d;
+}
+
+/* `hidden` is an attribute, and the rule above would otherwise beat it. */
+.progress[hidden] {
+    display: none;
+}
+
+.progress:focus-visible {
+    outline: 2px solid greenyellow;
+    outline-offset: -2px;
+}
+
+/* `steps()` rather than a smooth ease. A gradient sweep is the Material house
+   style and would look borrowed here; moving in discrete jumps matches the
+   pixel art and Press Start 2P. */
+.progress-bar {
+    width: 40%;
+    height: 100%;
+    background-color: greenyellow;
+    animation: progress-sweep 1.2s steps(10, end) infinite;
+}
+
+@keyframes progress-sweep {
+    from { transform: translateX(-100%); }
+    to   { transform: translateX(250%); }
+}
+
+/* A looping animation is exactly what this setting exists to suppress. The bar
+   still shows — losing it would put these players back where this change
+   started, on a page that looks like it did nothing — but it holds a partial
+   width so it can't be read as a completed bar. js/login.js pairs this with
+   surfacing the waking message immediately rather than at the threshold, so the
+   meaning is carried by text instead of motion. */
+@media (prefers-reduced-motion: reduce) {
+    .progress-bar {
+        animation: none;
+        width: 30%;
+    }
+}
+
+/* `min-height` on the slot rather than the messages, so the alert and the status
+   share one reserved line instead of claiming two. Reserving it at all is what
+   stops text appearing from shoving the switch prompt below down — under a thumb
    that may already be moving toward it. */
-.form-message {
+.form-message-slot {
     min-height: 16px;
     margin: 10px 0 0;
+}
+
+.form-message {
+    margin: 0;
     color: #ff6b6b;
     font-family: 'Press Start 2P', cursive;
     font-size: 10px;
     line-height: 1.6;
     text-align: center;
     overflow-wrap: break-word;
+}
+
+/* White, not the failure red: the server being slow is not an error. */
+.form-status {
+    color: white;
 }
 
 .form-switch {
@@ -275,5 +360,12 @@ input[type="submit"].form-field {
     .form-message,
     .form-switch {
         font-size: 8px;
+    }
+
+    /* The waking message is the longest string on the card and wraps to two
+       lines here, so the slot has to allow for both or the switch prompt jumps
+       when it appears. */
+    .form-message-slot {
+        min-height: 26px;
     }
 }

--- a/css/login.css
+++ b/css/login.css
@@ -140,13 +140,15 @@ input[type="password"].form-field:-webkit-autofill {
 /* The focused state is a border now rather than a box-shadow, so the autofill
    rule above no longer competes with it and needs nothing restated here. */
 
-/* Separates the submit from what precedes it — the progress strip, which in turn
-   sits below the password field. Without a gap the button butts against them and
-   reads as another input rather than the action that ends the form. Scoped by
-   input type like the rules above, so it can't add a gap between the text
-   fields. */
+/* Separates the submit from the password field above it. Without a gap the
+   button butts against it and reads as another input rather than the action that
+   ends the form. Scoped by input type like the rules above, so it can't add a
+   gap between the text fields.
+
+   This is the *idle* spacing only: while a request is in flight the button is
+   `display: none` and the bar's own margin sets the gap instead. */
 input[type="submit"].form-field {
-    margin-top: 8px;
+    margin-top: 24px;
 }
 
 .password-wrap {

--- a/js/login.js
+++ b/js/login.js
@@ -1,3 +1,18 @@
+// The two timing values, together, because they're the pair anyone tuning this
+// will reach for — the same reason js/touch-input.js keeps its own at the top.
+//
+// The delay exists because a warm instance can answer in under 200ms, and an
+// indicator that appears and vanishes inside a couple of frames reads as a
+// glitch rather than as progress. Delaying the *appearance* is safer than
+// holding it on screen for a minimum: it can only ever shorten the
+// interruption, never extend a wait that has already finished.
+const SHOW_DELAY_MS = 250
+const WAKING_MESSAGE_MS = 10000
+
+// Read live rather than cached: the setting can be changed while the page is
+// open, and `matches` is re-evaluated on every read.
+const reducedMotion = window.matchMedia("(prefers-reduced-motion: reduce)")
+
 const userLogin = document.querySelector("#user-login")
 const userSignUp = document.querySelector("#new-user-signup")
 
@@ -10,6 +25,21 @@ const showLoginButton = document.querySelector("#show-login")
 const passwordToggles = document.querySelectorAll(".password-toggle")
 
 localStorage.clear()
+
+// Starts Render waking while the player is still typing. The free tier spins the
+// instance down when idle and the first request back is what wakes it, so firing
+// one now can turn a 20-second submit into a short one.
+//
+// This is deliberately a tokenless GET to the scores endpoint, and the 401 it
+// answers with is the expected result — the response is thrown away entirely.
+// All that matters is that a request reached Render's router, which is what
+// triggers the spin-up; a 401, a 404, or even a CORS rejection wakes it just as
+// well as a 200 would. js/leaderboard.js fetches this same URL *with* a token
+// as a real scores request, so this is not that.
+//
+// The catch is load-bearing: without it, every visit to this page can log an
+// unhandled rejection for a request whose failure means nothing.
+fetch(API.scores).catch(() => {})
 
 // Which form is showing is a `signup-view` class on <body>: this file adds and
 // removes it, css/login.css decides what it means. Neither side reaches into
@@ -58,9 +88,103 @@ function maskPassword(toggle) {
     toggle.setAttribute("aria-label", "show password")
 }
 
+// One controller per form, so a login in flight can't touch the signup form's
+// button and vice versa. Each closes over its own two timer handles.
+//
+// Every one of those timers has to be cleared on the way out. A survivor paints
+// an indicator or a "still waking" line onto a form with nothing in flight, and
+// the threshold one does it ten seconds late — long enough after the attempt
+// that armed it to look like it came from nowhere.
+function pendingFor(form, indicator, status) {
+    let showTimer = null
+    let wakingTimer = null
+
+    return {
+        active: false,
+
+        start() {
+            this.active = true
+
+            showTimer = setTimeout(() => {
+                form.classList.add("pending")
+                indicator.hidden = false
+
+                // With motion suppressed the bar is static, so it shows *that*
+                // something is pending but no longer reads as ongoing work.
+                // Text takes over that job. The indicator's own label is reused
+                // rather than a second string, so the two can't drift apart.
+                if(reducedMotion.matches) {
+                    status.textContent = `${indicator.getAttribute("aria-label")}...`
+                }
+
+                // The CSS hides the submit button on this same class, and
+                // `visibility: hidden` drops focus exactly as `display: none`
+                // does. The player has usually just pressed Enter from the
+                // password field or clicked the button itself, so left alone
+                // focus lands on <body> and the next Tab restarts at the top of
+                // the page. The indicator is the element describing the state,
+                // so it is where focus belongs.
+                indicator.focus()
+            }, SHOW_DELAY_MS)
+
+            // Past this point the indicator alone stops being enough: it says
+            // something is happening but not why it's taking so long, and a
+            // silent 30-second wait reads as a hang no matter what is animating.
+            wakingTimer = setTimeout(() => {
+                status.textContent = "still waking the server..."
+            }, WAKING_MESSAGE_MS)
+        },
+
+        // Safe to call when nothing is pending — `pageshow` calls it on every
+        // page view, and clearTimeout(null) is a no-op.
+        stop() {
+            this.active = false
+            clearTimeout(showTimer)
+            clearTimeout(wakingTimer)
+            showTimer = null
+            wakingTimer = null
+            form.classList.remove("pending")
+            indicator.hidden = true
+            status.textContent = ""
+        }
+    }
+}
+
+const loginPending = pendingFor(
+    userLogin,
+    document.querySelector("#login-progress"),
+    document.querySelector("#login-status")
+)
+
+const signUpPending = pendingFor(
+    userSignUp,
+    document.querySelector("#signup-progress"),
+    document.querySelector("#signup-status")
+)
+
+// The back/forward cache restores this page with its DOM exactly as it was left,
+// so after a successful login it would come back with no submit button and a bar
+// still running. Nothing at the top level of this file re-runs on that restore —
+// which is also why the localStorage.clear() above doesn't fire — so the reset
+// needs its own hook. An ordinary load has nothing pending, making this a no-op
+// there and not worth branching on `event.persisted`.
+window.addEventListener("pageshow", () => {
+    loginPending.stop()
+    signUpPending.stop()
+})
+
 userSignUp.addEventListener("submit", event => {
     event.preventDefault()
+
+    // A hidden submit button does not stop a form submitting — Enter in a text
+    // field still fires this — so the guard lives here rather than relying on
+    // the button being gone. It engages now, not after SHOW_DELAY_MS, so a fast
+    // double-press is blocked during the window where nothing has visibly
+    // changed yet.
+    if(signUpPending.active) return
+
     signUpError.textContent = ""
+    signUpPending.start()
 
     const formData = new FormData(event.target)
 
@@ -80,6 +204,11 @@ userSignUp.addEventListener("submit", event => {
     })
     .then(parseJSON)
     .then(response => {
+        // Released on both branches. On success the view switches away from this
+        // form, and leaving it pending would mean toggling back later finds a
+        // form with no submit button and a bar still animating on it.
+        signUpPending.stop()
+
         // Success has no message of its own: landing on the login form says it,
         // and puts the player on the next thing they have to do rather than on
         // a sentence about what they just did. Signup still never navigates
@@ -88,12 +217,19 @@ userSignUp.addEventListener("submit", event => {
 
         failSignUp()
     })
-    .catch(failSignUp)
+    .catch(() => {
+        signUpPending.stop()
+        failSignUp()
+    })
 })
 
 userLogin.addEventListener("submit", event => {
     event.preventDefault()
+
+    if(loginPending.active) return
+
     loginError.textContent = ""
+    loginPending.start()
 
     const formData = new FormData(event.target)
 
@@ -115,12 +251,21 @@ userLogin.addEventListener("submit", event => {
         // what used to put the string "undefined" into localStorage and then
         // quietly decline to navigate, leaving the player looking at a page
         // that had told them nothing at all.
-        if(response.token === undefined) return failLogin()
+        if(response.token === undefined) {
+            loginPending.stop()
+            return failLogin()
+        }
 
+        // Deliberately still pending on the way out. The work isn't finished
+        // until the next page loads, and releasing here would flash the button
+        // back for a frame on a page that's already leaving.
         storeSession(response, user.username)
         window.location.href = "index.html"
     })
-    .catch(failLogin)
+    .catch(() => {
+        loginPending.stop()
+        failLogin()
+    })
 })
 
 function parseJSON(response) {

--- a/login.html
+++ b/login.html
@@ -44,8 +44,28 @@
                         </button>
                     </div>
 
+                    <!-- Takes no space at all until a request starts, at which
+                         point the submit button and the switch prompt below
+                         collapse and this takes their place.
+
+                         `role="progressbar"` with no `aria-valuenow` is what
+                         marks it indeterminate; there is no percentage to report
+                         because nothing here can tell a warm instance from a
+                         cold one. `tabindex="-1"` makes it a focus target for
+                         the script only: the button is hidden while the bar is
+                         up, which drops focus, so it has to land somewhere and
+                         this is the element that describes the state. -->
+                    <div class="progress" id="login-progress" role="progressbar" tabindex="-1" aria-label="logging in" hidden>
+                        <div class="progress-bar"></div>
+                    </div>
                     <input type="submit" value="Login" id="user-login-submit" class="form-field">
-                    <p id="login-error" class="form-message" role="alert"></p>
+                    <!-- Both messages share one reserved line: the alert is
+                         cleared on submit and only refills once the request has
+                         settled, by which time the status is gone. -->
+                    <div class="form-message-slot">
+                        <p id="login-error" class="form-message" role="alert"></p>
+                        <p id="login-status" class="form-message form-status" role="status"></p>
+                    </div>
                     <p class="form-switch">Don't have an account?
                         <button type="button" class="form-switch-button" id="show-signup">Sign up</button>
                     </p>
@@ -64,8 +84,14 @@
                         </button>
                     </div>
 
+                    <div class="progress" id="signup-progress" role="progressbar" tabindex="-1" aria-label="signing up" hidden>
+                        <div class="progress-bar"></div>
+                    </div>
                     <input type="submit" value="Sign Up" id="new-user-signup-submit" class="form-field">
-                    <p id="signup-error" class="form-message" role="alert"></p>
+                    <div class="form-message-slot">
+                        <p id="signup-error" class="form-message" role="alert"></p>
+                        <p id="signup-status" class="form-message form-status" role="status"></p>
+                    </div>
                     <p class="form-switch">Already have an account?
                         <button type="button" class="form-switch-button" id="show-login">Log in</button>
                     </p>


### PR DESCRIPTION
The backend is on Render's free tier and spins down when idle, so the first request back can take **20+ seconds**. The login page showed nothing for that whole window — a request in flight was indistinguishable from a click that never registered, and the natural response (clicking again) fired a second request at an instance already struggling to wake.

## What this does

**Prewarm on load.** A tokenless GET to `API.scores` when `login.html` loads starts the instance waking while the player is still typing. The 401 it answers with is thrown away — all that matters is that a request reached Render's router, which is what triggers the spin-up. A 404 or even a CORS rejection would work equally well.

**A pending state.** While a request is in flight the submit button and switch prompt collapse and an indeterminate progress bar takes their place. Past ten seconds a message explains the server is still coming up, so a long wait reads as expected rather than as a hang.

Both forms get it, and `CLAUDE.md` documents the load-bearing parts.

## Things a reviewer should look at

**`pageshow` is the back-button fix, and it's not optional.** A bfcache restore brings the DOM back exactly as it left and re-runs nothing at the top level of `js/login.js` — which is also why `localStorage.clear()` doesn't fire. Without it, a successful login followed by Back landed on a form with no submit button and a bar animating forever.

**The duplicate guard can't live on the button.** Enter in a text field submits the form whether or not the button is on screen, so the guard is the `active` check in the submit handler. It engages the moment the request is sent, not after the show delay, so a fast double-press is blocked during the window where nothing has visibly changed yet.

**Timer discipline.** Two timers per form, four in total. Each is cleared when its request settles, when a successful signup switches views, and on `pageshow`. A survivor would paint a bar or a "still waking" line onto a form with nothing in flight — the threshold one doing it ten seconds after the attempt that armed it.

**`display: none` here is the opposite of `css/game.css`**, which uses `visibility` on its game-over buttons specifically to *avoid* a layout shift. This page shifts on purpose. Both are right for their own page; neither should be "fixed" to match the other.

## Decisions worth recording

**No request timeout.** A hung request pends indefinitely. On a backend that legitimately takes 50+ seconds to wake, a timeout risks calling failure on a login that was about to succeed. This is a decision, not an oversight.

**The indicator tracks the request's lifetime, not a fixed duration.** A fixed 30 seconds was the original idea and would be wrong in both directions — still animating after a fast response landed, and stopping while a slow cold start was still running.

**Hiding the switch prompt narrows the spec**, which had required the toggle to stay usable mid-request. The cost: a player can't reach signup while a login is waking the server, and with no timeout a hung request leaves no route there short of reloading. What it buys is that two of the spec's nastiest edge cases — a response landing on a form nobody's looking at, and two requests pending at once — stop being reachable through the UI. The two controllers stay independent regardless.

**A storage flag for "backend is booted" was considered and rejected**, with the reasoning recorded in the spec so it isn't re-proposed.

## What changed after the plan was written

The plan designed the bar as an overlay covering the submit button, with `visibility: hidden` chosen to preserve the button's box. It worked exactly as designed and looked wrong — a bar the full height of a button reads as a button. It took three iterations to land on a 13px bar that collapses the controls instead. The plan's `## What changed during review` section records this, including that the focus move to the indicator turned out to be doing double duty: it's also the only thing announcing the pending state to a screen reader, since a bar appearing is otherwise purely visual.

## Verified

Stubbed fetches for the timing paths, real backend for the prewarm:

- Show delay: a response inside it never displays the bar and nothing collapses.
- Threshold: empty at 9s, `"still waking the server..."` at 11s.
- Duplicate guard: three submits during pending → **one** request.
- Release on every failure branch; retry works without reloading.
- Signup independence, and release on success as the view switches.
- Timer leak: idle after a completed attempt → nothing appears.
- **bfcache confirmed genuine** — an in-memory marker survived the round trip, proving the script never re-ran, and the form still came back fully reset.
- Reduced motion: `animation: none`, bar holds 30% so it can't read as complete.
- 390px: nothing overflows, message fits.
- Prewarm: exactly one GET, no UI trace, no storage write, console clean.

**Not verified:** the two timing values were never checked against a real cold start — all slow-path testing used stubbed fetches, so `WAKING_MESSAGE_MS = 10000` is a guess. And the reduced-motion *JS* branch keys off a top-level `const` that can't be overridden from the console; only the CSS half was exercised.

## Deploy

No new files — the tripwire stays at **77**.

## Commits

| | |
| --- | --- |
| `554a6b2` | spec |
| `3b441b2` | plan |
| `b9eff79` | implementation |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
