### PR TITLE
💅 style: fit the leaderboard's top ten, and the board in landscape

### DIFF
--- a/css/game.css
+++ b/css/game.css
@@ -223,6 +223,70 @@ canvas {
     }
 }
 
+/* Landscape on a phone, where height is the scarce axis rather than width:
+   ~390px of it, against a board that is 638px tall at native size.
+
+   Keyed on height and orientation rather than on the 560px width breakpoint,
+   because a phone on its side is *wide* — 844x390 is well over that breakpoint
+   and lands in the stacked tier above, sized as though it had room to spare.
+
+   This tier comes after the phone tier deliberately: a small window can match
+   both, and these rules need to win at equal specificity. */
+@media (orientation: landscape) and (max-height: 560px) {
+    /* Every pixel of height is board, so the 20px default drops to the least
+       that still shows the panel border clear of the screen edge. */
+    #game-container {
+        padding: 6px var(--panel-border);
+    }
+
+    /* The board is the whole page here. Stacked above it the dashboard costs
+       more height than the viewport has in total, and nothing that stacks fits,
+       so it goes — the instructions are readable in portrait and on the desktop
+       layout, and this orientation is for playing.
+
+       `display: none` rather than `visibility: hidden`, unlike the buttons
+       below: this needs the height back, not just the ink. */
+    #dashboard {
+        display: none;
+    }
+
+    /* Log Out and Leaderboard live in the dashboard and are the only way off
+       this page, so once the run is over it comes back. The board is finished
+       with by then, and the column can overflow into a scroll to reach it.
+
+       Same handoff as the buttons below — js/gamescene.js sets `game-over` on
+       <body> and this file decides what it means — so nothing in the scripts
+       needs to know this tier exists. */
+    body.game-over #dashboard {
+        display: flex;
+    }
+
+    /* Sized from the height, the opposite way round from every other tier. The
+       base rule's `width: 100%` would take the full 844px of a landscape phone
+       and derive a 1030px height from the aspect ratio; with a definite height
+       and `width: auto`, the ratio runs the other way and the width follows.
+
+       `min-width: 0` is what allows that. This is a flex item, so its
+       `min-width: auto` resolves to its content — and its content is the canvas
+       Phaser has already drawn at 524px. Without it the width can't go below
+       that, the aspect ratio never gets to derive anything, and the board
+       overflows the viewport at full size while the box around it is the right
+       shape. Nothing about the rule looks wrong when that happens.
+
+       Phaser's FIT mode measures this box and rescales the bitmap into it, so
+       the board stays whole and centred at whatever size the viewport allows,
+       and `max` in js/game.js still stops it upscaling past native. The bitmap
+       stays 518x632, so every gameplay coordinate is untouched.
+
+       18px is the 12px of container padding above plus the 6px the canvas's own
+       border needs, since that border is drawn outside this box. */
+    #canvas-container {
+        width: auto;
+        min-width: 0;
+        height: min(var(--panel-height), 100dvh - 18px);
+    }
+}
+
 /* Both buttons stay hidden through the start menu and active play, and are
    revealed once the knocked-out animation has looped: js/gamescene.js toggles
    `game-over` on <body>. Using visibility rather than display keeps their

--- a/css/game.css
+++ b/css/game.css
@@ -245,20 +245,21 @@ canvas {
        layout, and this orientation is for playing.
 
        `display: none` rather than `visibility: hidden`, unlike the buttons
-       below: this needs the height back, not just the ink. */
+       below: this needs the height back, not just the ink.
+
+       It stays hidden after a game over too, which is deliberate and is the one
+       thing here most likely to look like an oversight. Log Out and Leaderboard
+       live in the dashboard, so in landscape there is no way off this page but
+       to turn the phone back — and that was chosen over revealing it: bringing
+       a 638px panel back into a 390px viewport turns the moment you die into a
+       reflow and a scroll, and rotating is the cheaper gesture. Clicking to
+       play again, which is the common thing to do next, needs nothing revealed.
+
+       So there is no `body.game-over` override in this tier. The one below
+       still applies to the buttons, but it can't matter while their container
+       isn't rendered. */
     #dashboard {
         display: none;
-    }
-
-    /* Log Out and Leaderboard live in the dashboard and are the only way off
-       this page, so once the run is over it comes back. The board is finished
-       with by then, and the column can overflow into a scroll to reach it.
-
-       Same handoff as the buttons below — js/gamescene.js sets `game-over` on
-       <body> and this file decides what it means — so nothing in the scripts
-       needs to know this tier exists. */
-    body.game-over #dashboard {
-        display: flex;
     }
 
     /* Sized from the height, the opposite way round from every other tier. The

--- a/css/leaderboard.css
+++ b/css/leaderboard.css
@@ -19,15 +19,29 @@
 }
 
 /* Sized by .panel in shared.css, which caps it at the canvas's width and lets
-   it shrink below that on narrow viewports. The width cap is widened here and
-   the height left alone: the other panels are sized to the canvas so the game
-   isn't scaled, but this page has no canvas in it, and a wider box is what
-   keeps `username score` on one line. `width: 100%` still comes from .panel,
-   so narrow viewports shrink below this as before. */
+   it shrink below that on narrow viewports. Both of .panel's sizes are
+   overridden here, and for the same reason: they're derived from the game
+   canvas so the pixel art is never scaled, and this page has no canvas in it.
+   A wider box is what keeps `username score` on one line, and the height is
+   free to be whatever fits.
+
+   `width: 100%` still comes from .panel, so narrow viewports shrink below the
+   width cap as before. The height is the panel's usual height until the
+   viewport is too short for it, and then it's whatever the viewport has, less
+   the 20px #leaderboard-page pads above and below. That's the case a phone is
+   always in: without it the panel keeps its full height and pushes Return to
+   Game off the bottom of the screen.
+
+   Nothing is clipped when it engages, because #leaderboard scrolls on its own
+   — the title and the button hold their places and the list gives up the
+   height. `dvh` rather than `vh` so the shrinking mobile URL bar is counted;
+   `vh` is the tall-as-it-ever-gets value and would put the button back under
+   the browser chrome. */
 #leaderboard-container {
     display: flex;
     flex-direction: column;
     max-width: 760px;
+    height: min(var(--panel-outer-height), 100dvh - 40px);
     padding-bottom: 20px;
 }
 

--- a/css/leaderboard.css
+++ b/css/leaderboard.css
@@ -54,23 +54,49 @@
     padding-left: 0;
 }
 
-/* Press Start 2P is wide and usernames are arbitrary, so a long entry would
-   otherwise push the panel sideways and scroll the whole page horizontally. */
-#leaderboard li{
+/* Two columns, from the two spans js/leaderboard.js builds: the name runs from
+   the left edge and the score is pushed to the right one, so the scores line up
+   down the panel however long the names are.
+
+   The size is set here rather than inherited: entries used to be wrapped in an
+   `h1`, which supplied 2em and 0.67em margins of its own. Both are gone, so
+   this is the rendered size, and the row spacing is a fixed value instead of
+   margins that grow with it. A full top ten used to be 749px of content in a
+   463px list and scrolled; ten rows now measure 400px. */
+#leaderboard li {
+    display: flex;
+    justify-content: space-between;
+    gap: 16px;
+    margin-bottom: 12px;
     color: white;
     font-family: 'Press Start 2P', cursive;
-    font-size: 14px;
-    overflow-wrap: break-word;
+    font-size: 28px;
 }
 
-/* js/leaderboard.js wraps each entry in an `h1`, which brings a 2em font size
-   and 0.67em top and bottom margins with it. Both are sized off the `li`, so
-   the sizes here are what the font-size above is really setting: the rendered
-   entry is 28px, and the row spacing is set here rather than left to margins
-   that grow with it. A full top ten used to be 749px of content in a 463px
-   list; this is 400px, so it fits without scrolling. */
-#leaderboard li h1 {
-    margin: 0 0 12px 0;
+/* Press Start 2P is wide and usernames are arbitrary, so a long name would
+   otherwise push the panel sideways and scroll the whole page horizontally.
+   It truncates instead: every row stays one line tall, which is what keeps a
+   full top ten inside the panel no matter who is on it.
+
+   All four declarations are load-bearing and `text-overflow` alone does
+   nothing without the other three. `white-space: nowrap` is what creates the
+   overflow to trim — a name allowed to wrap never overflows in the first
+   place. `overflow: hidden` is what `text-overflow` describes; visible
+   overflow just spills. And `min-width: 0` is what allows the box to be
+   narrower than the text at all: a flex item defaults to `min-width: auto` and
+   refuses to shrink below its content, so without it the name would push the
+   score off the right edge and never reach the ellipsis. */
+.score-username {
+    min-width: 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+
+/* Never the column that gives: a wrapped score would break across lines mid
+   number, and it has far more right to the space than a 30-character name. */
+.score-points {
+    flex: none;
 }
 
 #return-to-game {
@@ -85,6 +111,7 @@
     }
 
     #leaderboard li {
-        font-size: 10px;
+        gap: 8px;
+        font-size: 20px;
     }
 }

--- a/css/leaderboard.css
+++ b/css/leaderboard.css
@@ -19,10 +19,15 @@
 }
 
 /* Sized by .panel in shared.css, which caps it at the canvas's width and lets
-   it shrink below that on narrow viewports. */
+   it shrink below that on narrow viewports. The width cap is widened here and
+   the height left alone: the other panels are sized to the canvas so the game
+   isn't scaled, but this page has no canvas in it, and a wider box is what
+   keeps `username score` on one line. `width: 100%` still comes from .panel,
+   so narrow viewports shrink below this as before. */
 #leaderboard-container {
     display: flex;
     flex-direction: column;
+    max-width: 760px;
     padding-bottom: 20px;
 }
 
@@ -54,7 +59,18 @@
 #leaderboard li{
     color: white;
     font-family: 'Press Start 2P', cursive;
+    font-size: 14px;
     overflow-wrap: break-word;
+}
+
+/* js/leaderboard.js wraps each entry in an `h1`, which brings a 2em font size
+   and 0.67em top and bottom margins with it. Both are sized off the `li`, so
+   the sizes here are what the font-size above is really setting: the rendered
+   entry is 28px, and the row spacing is set here rather than left to margins
+   that grow with it. A full top ten used to be 749px of content in a 463px
+   list; this is 400px, so it fits without scrolling. */
+#leaderboard li h1 {
+    margin: 0 0 12px 0;
 }
 
 #return-to-game {

--- a/css/leaderboard.css
+++ b/css/leaderboard.css
@@ -44,9 +44,29 @@
 }
 
 /* Only the list scrolls, so the title and Return to Game button stay put
-   even when a full top ten overruns the panel height. */
+   even when a full top ten overruns the panel height.
+
+   The list takes the leftover height and centres its rows in it, so a board
+   that isn't full sits in the middle of the panel rather than leaving all the
+   empty space in one block above the button.
+
+   `safe center` is the same guard as #leaderboard-page: plain centring
+   overflows a too-small box in *both* directions, and the top half of the
+   overflow is unreachable because scrolling can't go past the start edge.
+   `safe` falls back to start-alignment exactly when that would happen. The
+   unprefixed `center` before it is the fallback for browsers that don't parse
+   the keyword and would drop the whole declaration.
+
+   Row spacing is `gap` rather than a margin on the rows: a bottom margin on
+   the last row is counted in the centring, which would sit the list half a gap
+   high. */
 #leaderboard {
     flex: 1;
+    display: flex;
+    flex-direction: column;
+    justify-content: center;
+    justify-content: safe center;
+    gap: 12px;
     overflow-y: auto;
     margin: 0 auto 10px auto;
     width: 80%;
@@ -67,7 +87,6 @@
     display: flex;
     justify-content: space-between;
     gap: 16px;
-    margin-bottom: 12px;
     color: white;
     font-family: 'Press Start 2P', cursive;
     font-size: 28px;

--- a/js/leaderboard.js
+++ b/js/leaderboard.js
@@ -24,7 +24,35 @@ function displayScores(response) {
     const scores = Array.isArray(response) ? response : []
     clearLeaderboard(leaderboard)
     topTenScores(scores).map(score => appendScore(score))
+    markTruncatedNames()
 }
+
+// css/leaderboard.css truncates a name too long for its column to an ellipsis.
+// The characters are still in the DOM, just not on screen, so a tooltip is what
+// gets them back — but only for the names that are actually cut off, or every
+// short name would answer a hover with a tooltip repeating itself.
+//
+// `scrollWidth > clientWidth` is that test, and it's only answerable once the
+// row has been laid out, which is why this can't live in appendScore.
+//
+// It's re-run rather than done once because the answer changes: Press Start 2P
+// is wider than the fallback the first paint may use, so the real font clips
+// names the fallback didn't, and the column's width moves with the viewport.
+function markTruncatedNames() {
+    leaderboard.querySelectorAll(".score-username").forEach(name => {
+        if (name.scrollWidth > name.clientWidth) {
+            name.title = name.textContent
+        } else {
+            name.removeAttribute("title")
+        }
+    })
+}
+
+// Both of these can fire before there are any rows to measure — the fetch is
+// slow and the font may already be cached — and both are harmless then: the
+// pass finds nothing, and the one at the end of displayScores covers it.
+document.fonts.ready.then(markTruncatedNames)
+window.addEventListener("resize", markTruncatedNames)
 
 function topTenScores(scores) {
     let sortedScores = scores.sort((a, b) => (b.score - a.score))
@@ -46,9 +74,6 @@ function appendScore(score) {
     username.className = "score-username"
     points.className = "score-points"
     username.textContent = score.user.username
-    // A name too long for the column is truncated to an ellipsis by
-    // css/leaderboard.css, so carry the whole one in the tooltip.
-    username.title = score.user.username
     points.textContent = score.score
     scoreItem.append(username, points)
     leaderboard.appendChild(scoreItem)

--- a/js/leaderboard.js
+++ b/js/leaderboard.js
@@ -32,9 +32,25 @@ function topTenScores(scores) {
     return topScores
 }
 
+// Name and score are separate elements so css/leaderboard.css can put them in
+// two columns and line the scores up down the panel. As one interpolated
+// string they were a single text run, and nothing could align the second half.
+//
+// They're built with textContent rather than innerHTML because a username is
+// arbitrary text the account holder chose, and this string used to be parsed
+// as markup on every visitor's leaderboard.
 function appendScore(score) {
     let scoreItem = document.createElement('li')
-    scoreItem.innerHTML = `<h1>${score.user.username} ${score.score}</h1>`
+    let username = document.createElement('span')
+    let points = document.createElement('span')
+    username.className = "score-username"
+    points.className = "score-points"
+    username.textContent = score.user.username
+    // A name too long for the column is truncated to an ellipsis by
+    // css/leaderboard.css, so carry the whole one in the tooltip.
+    username.title = score.user.username
+    points.textContent = score.score
+    scoreItem.append(username, points)
     leaderboard.appendChild(scoreItem)
 }
 


### PR DESCRIPTION
Reworks the leaderboard so a full top ten fits the panel without scrolling, and so the scores read as a column instead of trailing whatever name precedes them. Also makes the game page playable in landscape on a phone — a separate page, kept here at the author's request rather than split into its own PR.

## Width and size

`#leaderboard-container` took its width from `.panel`, capped at `--panel-outer-width` (524px) — a value derived from the game canvas's outer box so the canvas is never scaled and the pixel art never blurs. This page has no canvas in it, so it was inheriting a constraint that buys it nothing. The cap moves to 760px here; the height stays put.

Shrinking the type alone wouldn't have paid off. Each entry was wrapped in an `<h1>`, which brought `font-size: 2em` **and** `0.67em` top/bottom margins, both sized off the `li` — the margins were ~40% of each row and scaled right along with any font-size reduction. Fixed row spacing is what makes the smaller type actually recover space.

## Two columns

Name and score were a single interpolated string, so nothing could align the second half. They're separate spans now, laid out as a flex row with `justify-content: space-between`. Measured across ten entries, every score's right edge lands on the same pixel, so the digits align on the units place.

Long names truncate to an ellipsis rather than wrapping. That's what makes the fit guarantee hold: **every row is exactly one line tall regardless of who is on the board**, where wrapping made row height depend on the names. `.score-username` needs all four of `min-width: 0`, `overflow: hidden`, `text-overflow: ellipsis`, and `white-space: nowrap` — drop any one and the ellipsis silently stops appearing. The full name is carried in a `title` tooltip, since truncation would otherwise make two long names indistinguishable.

The `<h1>` wrapper is gone; its size moves to the `li` unchanged (28px desktop, 20px mobile). Ten `<h1>`s in a list beside the real page title was odd semantically anyway.

## Vertical centring

The list takes the height left over by the title and the button, and its rows sat at the top of it — a board that isn't full left all the empty space in one block above the Return to Game button. It centres now: measured gaps above/below are 38px/38px at ten entries and 178px/178px at three.

`safe center`, the same guard `#leaderboard-page` uses — plain `center` overflows a too-small box in both directions and the half above the start edge can't be scrolled back to. Forced to 25 rows past the ten-entry cap, it falls back to start-alignment with the first row unclipped.

Row spacing moved from a bottom margin on the rows to `gap` on the list, because the last row's margin counts toward the centring and would have sat the list half a gap high.

## Security fix riding along

`appendScore` built its markup with `innerHTML`, interpolating `score.user.username` — which comes from signup — so markup in a name was parsed as HTML on every visitor's leaderboard. The spans are built with `textContent`, which can't parse anything. Splitting this into its own commit wasn't practical: it's the same rewritten function as the layout change.

## Game page: landscape on a phone (`css/game.css`)

A phone on its side is *wide* — 844x390 clears the 560px phone breakpoint and landed in the stacked tier, which gave it a full-height dashboard above a native 638px board inside ~390px of viewport. Playing meant scrolling between the top and bottom halves of the board.

The new tier is keyed on `(orientation: landscape) and (max-height: 560px)`, because height is the scarce axis there, not width. Two rules:

- **The board is sized from its height**, with the aspect ratio deriving the width — the reverse of every other tier. Phaser's FIT rescales the bitmap into that box; the bitmap stays 518x632, so no gameplay coordinate moves. `min-width: 0` is required: as a flex item the container's `min-width: auto` resolves to its content, which is the canvas Phaser already drew at 524px, so without it the box is the right shape but can't narrow and the board overflows at full size.
- **The dashboard is hidden**, since nothing that stacks fits — and it stays hidden after a game over, which is a deliberate product decision rather than an oversight. Revealing it would put a 638px panel back into a ~390px viewport at the moment the player dies, turning a game over into a reflow and a scroll; rotating the phone is the cheaper gesture, and clicking to play again needs nothing revealed. **Log Out and Leaderboard are therefore portrait-only.** The CSS comment says so, since this is the part most likely to be read as a bug later.

Measured at a stood-in 390px viewport height: board 311x378 including border (0.592 scale), dashboard `display: none` both during play and with `game-over` applied, board unchanged at game over, no page scroll.

⚠️ **Two things I could not verify.** The test window stopped accepting resizes mid-session, so this was checked by temporarily substituting a fixed height for `100dvh` and reloading. That confirms the arithmetic and Phaser's fit at boot, but **not** the media query firing on a real device, and **not** mid-session rotation — Phaser 3.16.2 did not re-fit when the box changed without a genuine resize event, and `game.scale.refresh()` didn't either. A real rotation fires `resize`, which is a different code path, so it likely works; if the board comes back wrong-sized after rotating, that's where to look, and the fix would be a JS resize listener rather than CSS. Worth a check on a phone before merging.

## Measured

Ten entries, 1280px-wide window:

| | before | after |
| --- | --- | --- |
| container | 524px | 760px |
| list content | 780px in a 463px box (scrolled) | 463px (no scroll) |
| rendered entry | 32px, 4 of 10 wrapped to two lines | 28px, one line each |
| score alignment | ends where the name ends | all right edges identical |

Checked with a 32-character username at a 6-digit score: truncates to `xXx_superlong…`, leaves `999999` intact, no horizontal page scroll. At the existing 560px mobile breakpoint rows are 20px and the same alignment holds. Press Start 2P has its own `…` glyph, so the ellipsis doesn't fall back to the `cursive` stack.

Verified in Chrome against the real page and the real webfont, not by inspection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
