### PR TITLE
🐛 fix: keep the opening bombs off the player's start cell

### DIFF
--- a/js/gamescene.js
+++ b/js/gamescene.js
@@ -166,10 +166,26 @@ class GameScene extends Phaser.Scene {
         gameState.ravegirl2.anims.play('ravegirl2', true)
         gameState.ravegirl3.anims.play('ravegirl3', true)
 
-        let randBomb1 = `bomb${Math.floor(Math.random() * 40) + 1}`;
+        // The two opening bombs skip any pattern covering the cell the player
+        // spawns on. 7 of the 40 patterns include it, so with two independent
+        // draws roughly a third of games used to end before the player had
+        // touched a key — nothing to react to, since the pattern is already
+        // running when create() hands over.
+        //
+        // Only the opening draws are restricted. The redraws after each
+        // explosion stay unrestricted: by then the player has had a full
+        // animation to move, and a bomb that can't cover where you're standing
+        // is a bomb you can ignore.
+        function drawBombAvoiding(cell) {
+            const safe = Object.keys(BOARD.explosionPositions).filter(pattern =>
+                !isArrayInArray(BOARD.explosionPositions[pattern], cell));
+            return safe[Math.floor(Math.random() * safe.length)];
+        }
+
+        let randBomb1 = drawBombAvoiding(getPlayerGridPosition(gameState.player));
         gameState.bomb1.anims.play(randBomb1, true)
 
-        let randBomb2 = `bomb${Math.floor(Math.random() * 40) + 1}`;
+        let randBomb2 = drawBombAvoiding(getPlayerGridPosition(gameState.player));
         gameState.bomb2.anims.play(randBomb2, true)
 
         let playerX; 


### PR DESCRIPTION
## What

The two bombs drawn when a game starts each picked from all 40 blast patterns. 7 of those patterns cover the spawn cell at `(37, 37)`, so with two independent draws roughly a third of games ended about two seconds in — and there was nothing to react to, because the pattern was already running by the time `create()` handed over.

Both opening draws now come from the 33 patterns that don't reach the cell the player is standing on, via a small `drawBombAvoiding(cell)` helper. The spawn cell is read through the existing `getPlayerGridPosition`, so it stays correct if the spawn ever moves.

The redraws after each explosion are deliberately left unrestricted: by then the player has had a full animation's worth of time to move, and a bomb that can't cover where you're standing is a bomb you can ignore.

## Testing

Served the repo locally and drove the real `create()`/`update()` path in the browser. (The automation tab was backgrounded and Chrome throttled it to zero animation frames, so the game loop was stepped by hand; the game-over score POST was stubbed, since the backend wasn't running.)

**With the fix — 100 rounds, player standing still at spawn:**
- 0 rounds where either opening bomb's pattern covers the spawn cell
- 0 deaths on the first explosion (frame ~117); earliest death was frame 237, the second cycle after an unrestricted redraw
- 33 distinct opening patterns drawn — the whole safe pool, so nothing is over-narrowed

**Control — fix temporarily reverted, 40 rounds:** 13 rounds (33%) drew an opening bomb covering the spawn, and exactly those 13 died at frame 117.

**A played round** (arrow keys dispatched into Phaser): `(37,37)` → `(177,37)` → `(180,180)`, collected 2 rave girls, still alive. Movement, collection, and scoring unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
